### PR TITLE
Fix #96: Use formData for generating authorization SMS OTP text

### DIFF
--- a/powerauth-bank-adapter-client/src/main/java/io/getlime/security/powerauth/lib/bankadapter/client/BankAdapterClient.java
+++ b/powerauth-bank-adapter-client/src/main/java/io/getlime/security/powerauth/lib/bankadapter/client/BankAdapterClient.java
@@ -17,7 +17,6 @@
 package io.getlime.security.powerauth.lib.bankadapter.client;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.getlime.core.rest.model.base.request.ObjectRequest;
 import io.getlime.core.rest.model.base.response.ObjectResponse;
@@ -29,6 +28,7 @@ import io.getlime.security.powerauth.lib.bankadapter.model.response.Authenticati
 import io.getlime.security.powerauth.lib.bankadapter.model.response.BankAccountListResponse;
 import io.getlime.security.powerauth.lib.bankadapter.model.response.CreateSMSAuthorizationResponse;
 import io.getlime.security.powerauth.lib.bankadapter.model.response.UserDetailResponse;
+import io.getlime.security.powerauth.lib.nextstep.model.entity.OperationFormData;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
@@ -142,17 +142,17 @@ public class BankAdapterClient {
     /**
      * Create authorization SMS OTP message.
      *
+     * @param operationId   Operation ID.
      * @param userId        User ID.
      * @param operationName Operation name.
-     * @param operationData Operation data in JSON format.
+     * @param formData      Operation form data.
      * @param lang          language for i18n.
      * @return Response with generated messageId.
      * @throws BankAdapterClientErrorException Exception thrown when action fails.
      */
-    public ObjectResponse<CreateSMSAuthorizationResponse> createAuthorizationSMS(String userId, String operationName, String operationData, String lang) throws BankAdapterClientErrorException {
+    public ObjectResponse<CreateSMSAuthorizationResponse> createAuthorizationSMS(String operationId, String userId, String operationName, OperationFormData formData, String lang) throws BankAdapterClientErrorException {
         try {
-            JsonNode operationDataJson = objectMapper.readTree(operationData);
-            CreateSMSAuthorizationRequest request = new CreateSMSAuthorizationRequest(userId, operationName, operationDataJson, lang);
+            CreateSMSAuthorizationRequest request = new CreateSMSAuthorizationRequest(operationId, userId, operationName, formData, lang);
             HttpEntity<ObjectRequest<CreateSMSAuthorizationRequest>> entity = new HttpEntity<>(new ObjectRequest<>(request));
             ResponseEntity<ObjectResponse<CreateSMSAuthorizationResponse>> response = defaultTemplate().exchange(
                     serviceUrl + "/api/auth/sms/create", HttpMethod.POST, entity,
@@ -167,8 +167,6 @@ public class BankAdapterClient {
             }
         } catch (ResourceAccessException ex) { // Bank Adapter service is down
             throw resourceAccessException(ex);
-        } catch (IOException ex) {
-            throw ioException(ex);
         }
     }
 

--- a/powerauth-bank-adapter-model/pom.xml
+++ b/powerauth-bank-adapter-model/pom.xml
@@ -24,6 +24,11 @@
             <artifactId>rest-model-base</artifactId>
             <version>1.0.2</version>
         </dependency>
+        <dependency>
+            <groupId>io.getlime.security</groupId>
+            <artifactId>powerauth-nextstep-model</artifactId>
+            <version>0.15.0</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/powerauth-bank-adapter-model/src/main/java/io/getlime/security/powerauth/lib/bankadapter/model/request/CreateSMSAuthorizationRequest.java
+++ b/powerauth-bank-adapter-model/src/main/java/io/getlime/security/powerauth/lib/bankadapter/model/request/CreateSMSAuthorizationRequest.java
@@ -15,8 +15,7 @@
  */
 package io.getlime.security.powerauth.lib.bankadapter.model.request;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.getlime.security.powerauth.lib.nextstep.model.entity.OperationFormData;
 
 /**
  * Request for creating SMS OTP authorization message.
@@ -24,6 +23,11 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  * @author Roman Strobl, roman.strobl@lime-company.eu
  */
 public class CreateSMSAuthorizationRequest {
+
+    /**
+     * Operation ID related to this authorization request.
+     */
+    private String operationId;
 
     /**
      * User ID for this authorization request.
@@ -36,9 +40,9 @@ public class CreateSMSAuthorizationRequest {
     private String operationName;
 
     /**
-     * Operation data in JSON format.
+     * Operation formData.
      */
-    private JsonNode operationData;
+    private OperationFormData formData;
 
     /**
      * Language used in the SMS OTP messages.
@@ -48,11 +52,20 @@ public class CreateSMSAuthorizationRequest {
     public CreateSMSAuthorizationRequest() {
     }
 
-    public CreateSMSAuthorizationRequest(String userId, String operationName, JsonNode operationData, String lang) {
+    public CreateSMSAuthorizationRequest(String operationId, String userId, String operationName, OperationFormData formData, String lang) {
+        this.operationId = operationId;
         this.userId = userId;
         this.operationName = operationName;
-        this.operationData = operationData;
+        this.formData = formData;
         this.lang = lang;
+    }
+
+    public String getOperationId() {
+        return operationId;
+    }
+
+    public void setOperationId(String operationId) {
+        this.operationId = operationId;
     }
 
     public String getUserId() {
@@ -71,12 +84,12 @@ public class CreateSMSAuthorizationRequest {
         this.operationName = operationName;
     }
 
-    public JsonNode getOperationData() {
-        return operationData;
+    public OperationFormData getFormData() {
+        return formData;
     }
 
-    public void setOperationData(ObjectNode operationData) {
-        this.operationData = operationData;
+    public void setFormData(OperationFormData formData) {
+        this.formData = formData;
     }
 
     public String getLang() {

--- a/powerauth-bank-adapter-model/src/main/java/io/getlime/security/powerauth/lib/bankadapter/model/request/CreateSMSAuthorizationRequest.java
+++ b/powerauth-bank-adapter-model/src/main/java/io/getlime/security/powerauth/lib/bankadapter/model/request/CreateSMSAuthorizationRequest.java
@@ -42,7 +42,7 @@ public class CreateSMSAuthorizationRequest {
     /**
      * Operation formData.
      */
-    private OperationFormData formData;
+    private OperationFormData operationFormData;
 
     /**
      * Language used in the SMS OTP messages.
@@ -52,11 +52,12 @@ public class CreateSMSAuthorizationRequest {
     public CreateSMSAuthorizationRequest() {
     }
 
-    public CreateSMSAuthorizationRequest(String operationId, String userId, String operationName, OperationFormData formData, String lang) {
+    public CreateSMSAuthorizationRequest(String operationId, String userId, String operationName,
+                                         OperationFormData operationFormData, String lang) {
         this.operationId = operationId;
         this.userId = userId;
         this.operationName = operationName;
-        this.formData = formData;
+        this.operationFormData = operationFormData;
         this.lang = lang;
     }
 
@@ -84,12 +85,12 @@ public class CreateSMSAuthorizationRequest {
         this.operationName = operationName;
     }
 
-    public OperationFormData getFormData() {
-        return formData;
+    public OperationFormData getOperationFormData() {
+        return operationFormData;
     }
 
-    public void setFormData(OperationFormData formData) {
-        this.formData = formData;
+    public void setOperationFormData(OperationFormData operationFormData) {
+        this.operationFormData = operationFormData;
     }
 
     public String getLang() {

--- a/powerauth-bank-adapter/src/main/java/io/getlime/security/powerauth/lib/bankadapter/controller/SMSAuthorizationController.java
+++ b/powerauth-bank-adapter/src/main/java/io/getlime/security/powerauth/lib/bankadapter/controller/SMSAuthorizationController.java
@@ -103,10 +103,10 @@ public class SMSAuthorizationController {
         String messageId = UUID.randomUUID().toString();
 
         // update names of operationData JSON fields if necessary
-        OperationAmountAttribute amountAttribute = operationFormDataService.getAmount(createSMSAuthorizationRequest.getFormData());
+        OperationAmountAttribute amountAttribute = operationFormDataService.getAmount(createSMSAuthorizationRequest.getOperationFormData());
         BigDecimal amount = amountAttribute.getAmount();
         String currency = amountAttribute.getCurrency();
-        String account = operationFormDataService.getAccount(createSMSAuthorizationRequest.getFormData());
+        String account = operationFormDataService.getAccount(createSMSAuthorizationRequest.getOperationFormData());
 
         // update localized SMS message text in resources
         String authorizationCode = generateAuthorizationCode(amount, currency, account);

--- a/powerauth-bank-adapter/src/main/java/io/getlime/security/powerauth/lib/bankadapter/repository/model/entity/SMSAuthorizationEntity.java
+++ b/powerauth-bank-adapter/src/main/java/io/getlime/security/powerauth/lib/bankadapter/repository/model/entity/SMSAuthorizationEntity.java
@@ -37,14 +37,14 @@ public class SMSAuthorizationEntity implements Serializable {
     @Column(name = "message_id")
     private String messageId;
 
+    @Column(name = "operation_id")
+    private String operationId;
+
     @Column(name = "user_id")
     private String userId;
 
     @Column(name = "operation_name")
     private String operationName;
-
-    @Column(name = "operation_data")
-    private String operationData;
 
     @Column(name = "authorization_code")
     private String authorizationCode;
@@ -75,6 +75,14 @@ public class SMSAuthorizationEntity implements Serializable {
         this.messageId = messageId;
     }
 
+    public String getOperationId() {
+        return operationId;
+    }
+
+    public void setOperationId(String operationId) {
+        this.operationId = operationId;
+    }
+
     public String getUserId() {
         return userId;
     }
@@ -89,14 +97,6 @@ public class SMSAuthorizationEntity implements Serializable {
 
     public void setOperationName(String operationName) {
         this.operationName = operationName;
-    }
-
-    public String getOperationData() {
-        return operationData;
-    }
-
-    public void setOperationData(String operationData) {
-        this.operationData = operationData;
     }
 
     public String getAuthorizationCode() {

--- a/powerauth-bank-adapter/src/main/java/io/getlime/security/powerauth/lib/bankadapter/service/OperationFormDataService.java
+++ b/powerauth-bank-adapter/src/main/java/io/getlime/security/powerauth/lib/bankadapter/service/OperationFormDataService.java
@@ -1,0 +1,46 @@
+package io.getlime.security.powerauth.lib.bankadapter.service;
+
+import io.getlime.security.powerauth.lib.nextstep.model.entity.OperationAmountAttribute;
+import io.getlime.security.powerauth.lib.nextstep.model.entity.OperationFormAttribute;
+import io.getlime.security.powerauth.lib.nextstep.model.entity.OperationFormData;
+import io.getlime.security.powerauth.lib.nextstep.model.entity.OperationKeyValueAttribute;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service which extracts form data from an operation based on required input for SMS text.
+ *
+ * @author Roman Strobl
+ */
+@Service
+public class OperationFormDataService {
+
+    private static final String LABEL_TO_ACCOUNT = "To Account";
+
+    public OperationAmountAttribute getAmount(OperationFormData formData) {
+        if (formData==null || formData.getParameters()==null) {
+            throw new IllegalArgumentException("Argument formData is invalid.");
+        }
+        for (OperationFormAttribute attribute: formData.getParameters()) {
+            if (attribute.getType()==OperationFormAttribute.Type.AMOUNT) {
+                return (OperationAmountAttribute) attribute;
+            }
+        }
+        return null;
+    }
+
+    public String getAccount(OperationFormData formData) {
+        if (formData==null || formData.getParameters()==null) {
+            throw new IllegalArgumentException("Argument formData is invalid.");
+        }
+        for (OperationFormAttribute attribute: formData.getParameters()) {
+            if (attribute.getType()==OperationFormAttribute.Type.KEY_VALUE) {
+                OperationKeyValueAttribute keyValueAttribute = (OperationKeyValueAttribute) attribute;
+                if (keyValueAttribute.getLabel().equals(LABEL_TO_ACCOUNT)) {
+                    return keyValueAttribute.getValue();
+                }
+            }
+        }
+        return null;
+    }
+
+}

--- a/powerauth-bank-adapter/src/main/java/io/getlime/security/powerauth/lib/bankadapter/validation/CreateSMSAuthorizationRequestValidator.java
+++ b/powerauth-bank-adapter/src/main/java/io/getlime/security/powerauth/lib/bankadapter/validation/CreateSMSAuthorizationRequestValidator.java
@@ -64,20 +64,20 @@ public class CreateSMSAuthorizationRequestValidator implements Validator {
             errors.rejectValue("operationName", "smsAuthorization.operationName.long");
         }
 
-        OperationAmountAttribute amountAttribute = operationFormDataService.getAmount(authRequest.getFormData());
+        OperationAmountAttribute amountAttribute = operationFormDataService.getAmount(authRequest.getOperationFormData());
         BigDecimal amount = amountAttribute.getAmount();
         String currency = amountAttribute.getCurrency();
-        String account = operationFormDataService.getAccount(authRequest.getFormData());
+        String account = operationFormDataService.getAccount(authRequest.getOperationFormData());
         if (amount == null) {
-            errors.rejectValue("operationData", "smsAuthorization.amount.empty");
+            errors.rejectValue("operationFormData", "smsAuthorization.amount.empty");
         } else if (amount.doubleValue()<=0) {
-            errors.rejectValue("operationData", "smsAuthorization.amount.invalid");
+            errors.rejectValue("operationFormData", "smsAuthorization.amount.invalid");
         }
         if (currency == null || currency.isEmpty()) {
-            errors.rejectValue("operationData", "smsAuthorization.currency.empty");
+            errors.rejectValue("operationFormData", "smsAuthorization.currency.empty");
         }
         if (account == null || account.isEmpty()) {
-            errors.rejectValue("operationData", "smsAuthorization.account.empty");
+            errors.rejectValue("operationFormData", "smsAuthorization.account.empty");
         }
 
     }

--- a/powerauth-bank-adapter/src/main/resources/application.properties
+++ b/powerauth-bank-adapter/src/main/resources/application.properties
@@ -4,10 +4,14 @@ spring.datasource.test-while-idle=true
 spring.datasource.test-on-borrow=true
 spring.datasource.validation-query=SELECT 1
 # Database Configuration - MySQL
-spring.datasource.url=jdbc:mysql://localhost:3306/powerauth?characterEncoding=UTF-8
+spring.datasource.url=jdbc:mysql://localhost:3306/powerauth
 spring.datasource.username=powerauth
 spring.datasource.password=
 spring.datasource.driver-class-name=com.mysql.jdbc.Driver
+spring.jpa.properties.hibernate.connection.CharSet=utf8mb4
+spring.jpa.properties.hibernate.connection.characterEncoding=utf8
+spring.jpa.properties.hibernate.connection.useUnicode=true
+
 # SMS OTP expiration time in seconds
 powerauth.authorization.sms-otp.expiration-time-in-seconds=300
 # Maximum number of tries to verify a SMS OTP authorization code

--- a/powerauth-nextstep/src/main/resources/application.properties
+++ b/powerauth-nextstep/src/main/resources/application.properties
@@ -3,9 +3,13 @@ spring.datasource.test-while-idle=true
 spring.datasource.test-on-borrow=true
 spring.datasource.validation-query=SELECT 1
 # Database Configuration - MySQL
-spring.datasource.url=jdbc:mysql://localhost:3306/powerauth?characterEncoding=UTF-8
+spring.datasource.url=jdbc:mysql://localhost:3306/powerauth
 spring.datasource.username=powerauth
 spring.datasource.password=
 spring.datasource.driver-class-name=com.mysql.jdbc.Driver
+spring.jpa.properties.hibernate.connection.CharSet=utf8mb4
+spring.jpa.properties.hibernate.connection.characterEncoding=utf8
+spring.jpa.properties.hibernate.connection.useUnicode=true
+
 # Operation expiration time in seconds
 powerauth.nextstep.operation.expirationTimeInSeconds=300

--- a/powerauth-webflow-authentication-sms/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/sms/controller/SMSAuthorizationController.java
+++ b/powerauth-webflow-authentication-sms/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/sms/controller/SMSAuthorizationController.java
@@ -94,7 +94,9 @@ public class SMSAuthorizationController extends AuthMethodController<SMSAuthoriz
         final String userId = operation.getUserId();
         SMSAuthorizationResponse initResponse = new SMSAuthorizationResponse();
         try {
-            ObjectResponse<CreateSMSAuthorizationResponse> baResponse = bankAdapterClient.createAuthorizationSMS(userId, operation.getOperationName(), operation.getOperationData(), LocaleContextHolder.getLocale().getLanguage());
+            ObjectResponse<CreateSMSAuthorizationResponse> baResponse = bankAdapterClient.createAuthorizationSMS(
+                    operation.getOperationId(), userId, operation.getOperationName(), operation.getFormData(),
+                    LocaleContextHolder.getLocale().getLanguage());
             String messageId = baResponse.getResponseObject().getMessageId();
             httpSession.setAttribute(MESSAGE_ID, messageId);
             initResponse.setResult(AuthStepResult.CONFIRMED);

--- a/powerauth-webflow-client/src/main/resources/application.properties
+++ b/powerauth-webflow-client/src/main/resources/application.properties
@@ -13,9 +13,12 @@ spring.datasource.test-while-idle=true
 spring.datasource.test-on-borrow=true
 spring.datasource.validation-query=SELECT 1
 # Database Configuration - MySQL
-spring.datasource.url=jdbc:mysql://localhost:3306/powerauth?characterEncoding=UTF-8
+spring.datasource.url=jdbc:mysql://localhost:3306/powerauth
 spring.datasource.username=powerauth
 spring.datasource.password=
 spring.datasource.driver-class-name=com.mysql.jdbc.Driver
+spring.jpa.properties.hibernate.connection.CharSet=utf8mb4
+spring.jpa.properties.hibernate.connection.characterEncoding=utf8
+spring.jpa.properties.hibernate.connection.useUnicode=true
 # Hibernate Configuration
 spring.jpa.hibernate.ddl-auto=create

--- a/powerauth-webflow-docs/sql/mysql/create_schema.sql
+++ b/powerauth-webflow-docs/sql/mysql/create_schema.sql
@@ -78,7 +78,7 @@ CREATE TABLE ns_user_prefs (
 CREATE TABLE ns_operation (
   operation_id              VARCHAR(256) PRIMARY KEY,
   operation_name            VARCHAR(32),
-  operation_data            VARCHAR(4096),
+  operation_data            TEXT,
   operation_form_data       TEXT,
   user_id                   VARCHAR(256),
   result                    VARCHAR(32),
@@ -117,11 +117,11 @@ CREATE TABLE ns_step_definition (
 
 CREATE TABLE ba_sms_authorization (
   message_id           VARCHAR(256) PRIMARY KEY,
+  operation_id         VARCHAR(256),
   user_id              VARCHAR(256),
   operation_name       VARCHAR(32),
-  operation_data       VARCHAR(4096),
   authorization_code   VARCHAR(32),
-  message_text         VARCHAR(256),
+  message_text         TEXT,
   verify_request_count INTEGER,
   verified             BOOLEAN,
   timestamp_created    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,

--- a/powerauth-webflow/src/main/resources/application.properties
+++ b/powerauth-webflow/src/main/resources/application.properties
@@ -24,5 +24,8 @@ spring.datasource.url=jdbc:mysql://localhost:3306/powerauth
 spring.datasource.username=powerauth
 spring.datasource.password=
 spring.datasource.driver-class-name=com.mysql.jdbc.Driver
+spring.jpa.properties.hibernate.connection.CharSet=utf8mb4
+spring.jpa.properties.hibernate.connection.characterEncoding=utf8
+spring.jpa.properties.hibernate.connection.useUnicode=true
 # Hibernate Configuration
 spring.jpa.hibernate.ddl-auto=create

--- a/powerauth-webflow/src/main/resources/application.properties
+++ b/powerauth-webflow/src/main/resources/application.properties
@@ -20,7 +20,7 @@ spring.datasource.test-while-idle=true
 spring.datasource.test-on-borrow=true
 spring.datasource.validation-query=SELECT 1
 # Database Configuration - MySQL
-spring.datasource.url=jdbc:mysql://localhost:3306/powerauth?characterEncoding=UTF-8
+spring.datasource.url=jdbc:mysql://localhost:3306/powerauth
 spring.datasource.username=powerauth
 spring.datasource.password=
 spring.datasource.driver-class-name=com.mysql.jdbc.Driver


### PR DESCRIPTION
Note that this change contains DDL changes in ba_sms_authorization table.

Full change log:
* Fix #96: Use formData for generating authorization SMS OTP text
* Updated ba_sms_authorization table and related entity not to contain data, just reference an operation instead
* Finished migration to utf8mb4 character encoding for MySQL
* Switched to TEXT data type for columns where we do not control text size (and it may be bigger thanks to utf8mb4)
