### PR TITLE
Fix #115: Store `salt` from DataDigest object when generating SMS OTP

### DIFF
--- a/powerauth-bank-adapter/src/main/java/io/getlime/security/powerauth/lib/bankadapter/repository/model/entity/SMSAuthorizationEntity.java
+++ b/powerauth-bank-adapter/src/main/java/io/getlime/security/powerauth/lib/bankadapter/repository/model/entity/SMSAuthorizationEntity.java
@@ -49,6 +49,9 @@ public class SMSAuthorizationEntity implements Serializable {
     @Column(name = "authorization_code")
     private String authorizationCode;
 
+    @Column(name = "salt")
+    private byte[] salt;
+
     @Column(name = "message_text")
     private String messageText;
 
@@ -105,6 +108,14 @@ public class SMSAuthorizationEntity implements Serializable {
 
     public void setAuthorizationCode(String authorizationCode) {
         this.authorizationCode = authorizationCode;
+    }
+
+    public byte[] getSalt() {
+        return salt;
+    }
+
+    public void setSalt(byte[] salt) {
+        this.salt = salt;
     }
 
     public String getMessageText() {

--- a/powerauth-webflow-docs/sql/mysql/create_schema.sql
+++ b/powerauth-webflow-docs/sql/mysql/create_schema.sql
@@ -130,6 +130,7 @@ CREATE TABLE ba_sms_authorization (
   user_id              VARCHAR(256),
   operation_name       VARCHAR(32),
   authorization_code   VARCHAR(32),
+  salt                 VARBINARY(16),
   message_text         TEXT,
   verify_request_count INTEGER,
   verified             BOOLEAN,

--- a/powerauth-webflow-docs/sql/oracle/create_schema.sql
+++ b/powerauth-webflow-docs/sql/oracle/create_schema.sql
@@ -130,6 +130,7 @@ CREATE TABLE ba_sms_authorization (
   user_id              VARCHAR(256),
   operation_name       VARCHAR(32),
   authorization_code   VARCHAR(32),
+  salt                 RAW(16),
   message_text         CLOB,
   verify_request_count INTEGER,
   verified             NUMBER(1) DEFAULT 0,


### PR DESCRIPTION
Again, a small DDL change is present.