### PR TITLE
Fix #102: Clicking twice on Cancel leads to a 500 error

### DIFF
--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/StepResolutionService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/StepResolutionService.java
@@ -359,7 +359,11 @@ public class StepResolutionService {
                 throw new IllegalStateException("Operation update failed, because operation is already in DONE state (operationId: " + request.getOperationId() + ").");
             }
             if (historyItem.getResponseResult() == AuthResult.FAILED) {
-                throw new IllegalStateException("Operation update failed, because operation is already in FAILED state (operationId: " + request.getOperationId() + ").");
+                // #102 - allow double cancellation requests, cancel requests may come from multiple channels, so this is a supported scenario
+                if (operationEntity.getCurrentOperationHistoryEntity().getRequestAuthStepResult() != AuthStepResult.CANCELED
+                        || request.getAuthStepResult() != AuthStepResult.CANCELED) {
+                    throw new IllegalStateException("Operation update failed, because operation is already in FAILED state (operationId: " + request.getOperationId() + ").");
+                }
             }
         }
     }


### PR DESCRIPTION
Double cancelations are now supported. All additional cancellation requests are recorded in operation history and the operation remains in FAILED/CANCELED state.