### PR TITLE
Fix #117: Support switch from offline mode back to online mode

### DIFF
--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileTokenOfflineController.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileTokenOfflineController.java
@@ -57,14 +57,14 @@ import java.util.List;
  * @author Roman Strobl, roman.strobl@lime-company.eu
  */
 @Controller
-@RequestMapping(value = "/api/auth/qr")
-public class QRCodeController extends AuthMethodController<QRCodeAuthenticationRequest, QRCodeAuthenticationResponse, AuthStepException> {
+@RequestMapping(value = "/api/auth/token/offline")
+public class MobileTokenOfflineController extends AuthMethodController<QRCodeAuthenticationRequest, QRCodeAuthenticationResponse, AuthStepException> {
 
     private final PowerAuthServiceClient powerAuthServiceClient;
     private final AuthMethodQueryService authMethodQueryService;
 
     @Autowired
-    public QRCodeController(PowerAuthServiceClient powerAuthServiceClient, AuthMethodQueryService authMethodQueryService) {
+    public MobileTokenOfflineController(PowerAuthServiceClient powerAuthServiceClient, AuthMethodQueryService authMethodQueryService) {
         this.powerAuthServiceClient = powerAuthServiceClient;
         this.authMethodQueryService = authMethodQueryService;
     }
@@ -256,10 +256,11 @@ public class QRCodeController extends AuthMethodController<QRCodeAuthenticationR
     /**
      * Generates the QR code based on operation data.
      *
+     * @param activation Activation entity.
      * @return QR code as String-based PNG image.
-     * @throws IOException Thrown when generating QR code fails.
+     * @throws QRCodeInvalidDataException Thrown when data is invalid.
      */
-    private OfflineSignatureQrCode generateQRCode(ActivationEntity activation) throws IOException, QRCodeInvalidDataException {
+    private OfflineSignatureQrCode generateQRCode(ActivationEntity activation) throws QRCodeInvalidDataException {
         GetOperationDetailResponse operation = getOperation();
         String operationData = operation.getOperationData();
         String messageText = operation.getFormData().getMessage();

--- a/powerauth-webflow/src/main/js/actions/operationReviewActions.js
+++ b/powerauth-webflow/src/main/js/actions/operationReviewActions.js
@@ -23,20 +23,11 @@ export function getOperationData() {
                 // if authMethod is already chosen, skip choice and go directly to the authMethod
                 switch (response.data.formData.userInput.chosenAuthMethod) {
                     case "POWERAUTH_TOKEN":
-                        // choice between online and offline modes
-                        if (response.data.formData.userInput.offlineModeEnabled) {
-                            dispatch({
-                                type: "SHOW_SCREEN_QR_CODE",
-                                payload: response.data
-                            });
-                            return;
-                        } else {
-                            dispatch({
-                                type: "SHOW_SCREEN_TOKEN",
-                                payload: response.data
-                            });
-                            return;
-                        }
+                        dispatch({
+                            type: "SHOW_SCREEN_TOKEN",
+                            payload: response.data
+                        });
+                        return;
                     case "SMS_KEY":
                         dispatch({
                             type: "SHOW_SCREEN_SMS",

--- a/powerauth-webflow/src/main/js/actions/tokenAuthOfflineActions.js
+++ b/powerauth-webflow/src/main/js/actions/tokenAuthOfflineActions.js
@@ -16,23 +16,10 @@
 import axios from "axios";
 import {dispatchAction, dispatchError} from "../dispatcher/dispatcher";
 
-export function getOperationData() {
-    return function (dispatch) {
-        axios.get("./api/auth/operation/detail").then((response) => {
-            dispatch({
-                type: "SHOW_SCREEN_QR_CODE",
-                payload: response.data
-            });
-        }).catch((error) => {
-            dispatchError(dispatch, error);
-        })
-    }
-}
-
-export function initQRCode(activationId) {
+export function initOffline(activationId) {
     return function (dispatch) {
         dispatch({
-            type: "SHOW_SCREEN_QR_CODE",
+            type: "SHOW_SCREEN_TOKEN",
             payload: {
                 loading: true,
                 error: false,
@@ -40,7 +27,7 @@ export function initQRCode(activationId) {
                 message: ""
             }
         });
-        axios.post("./api/auth/qr/init", {
+        axios.post("./api/auth/token/offline/init", {
             activationId: activationId
         }).then((response) => {
             if (response.data.result === 'AUTH_FAILED') {
@@ -48,7 +35,7 @@ export function initQRCode(activationId) {
                 return;
             }
             dispatch({
-                type: "SHOW_SCREEN_QR_CODE",
+                type: "SHOW_SCREEN_TOKEN",
                 payload: {
                     loading: false,
                     error: false,
@@ -79,10 +66,10 @@ export function changeActivation(activation) {
     }
 }
 
-export function authenticate(activationId, authCode, nonce, dataHash) {
+export function authenticateOffline(activationId, authCode, nonce, dataHash) {
     return function (dispatch) {
         dispatch({
-            type: "SHOW_SCREEN_QR_CODE",
+            type: "SHOW_SCREEN_TOKEN",
             payload: {
                 loading: true,
                 error: false,
@@ -90,14 +77,14 @@ export function authenticate(activationId, authCode, nonce, dataHash) {
                 message: ""
             }
         });
-        axios.post("./api/auth/qr/authenticate", {
+        axios.post("./api/auth/token/offline/authenticate", {
             activationId: activationId,
             authCode: authCode,
             nonce: nonce,
             dataHash: dataHash
         }).then((response) => {
             dispatch({
-                type: "SHOW_SCREEN_QR_CODE",
+                type: "SHOW_SCREEN_TOKEN",
                 payload: {
                     loading: true,
                     error: false,
@@ -137,7 +124,7 @@ export function authenticate(activationId, authCode, nonce, dataHash) {
                         break;
                     }
                     dispatch({
-                        type: "SHOW_SCREEN_QR_CODE",
+                        type: "SHOW_SCREEN_TOKEN",
                         payload: {
                             loading: false,
                             error: true,
@@ -154,17 +141,3 @@ export function authenticate(activationId, authCode, nonce, dataHash) {
     }
 }
 
-export function cancel() {
-    return function (dispatch) {
-        axios.post("./api/auth/qr/cancel", {}).then((response) => {
-            dispatch({
-                type: "SHOW_SCREEN_ERROR",
-                payload: {
-                    message: response.data.message
-                }
-            });
-        }).catch((error) => {
-            dispatchError(dispatch, error);
-        })
-    }
-}

--- a/powerauth-webflow/src/main/js/actions/tokenAuthOnlineActions.js
+++ b/powerauth-webflow/src/main/js/actions/tokenAuthOnlineActions.js
@@ -29,7 +29,7 @@ export function getOperationData() {
     }
 }
 
-export function init(callback) {
+export function initOnline(callback) {
     return function (dispatch) {
         axios.post("./api/auth/token/web/init", {}).then((response) => {
             // silently ignore push message failures, see #125
@@ -49,7 +49,7 @@ export function init(callback) {
     }
 }
 
-export function authenticate(callback) {
+export function authenticateOnline(callback) {
     return function (dispatch) {
         axios.post("./api/auth/token/web/authenticate", {}).then((response) => {
             switch (response.data.result) {

--- a/powerauth-webflow/src/main/js/components/app.js
+++ b/powerauth-webflow/src/main/js/components/app.js
@@ -10,7 +10,6 @@ import Token from "./tokenAuth";
 import SMSAuthorization from "./smsAuth";
 // i18n
 import {injectIntl} from "react-intl";
-import QRCode from "./qrCodeAuth";
 
 /**
  * The App class is the main React component of this application. It handles incoming WebSocket messages
@@ -69,10 +68,6 @@ export class App extends React.Component {
                 Component = Token;
                 break;
             }
-            case "SCREEN_QR_CODE": {
-                Component = QRCode;
-                break;
-            }
             case "SCREEN_SMS": {
                 Component = SMSAuthorization;
                 break;
@@ -96,7 +91,7 @@ export class App extends React.Component {
                     )}
                 </div>
                 <div id="home" className="text-center">
-                    <div id="logo"></div>
+                    <div id="logo"/>
                     <Component intl={this.props.intl}/>
                 </div>
             </div>

--- a/powerauth-webflow/src/main/js/components/tokenAuth.js
+++ b/powerauth-webflow/src/main/js/components/tokenAuth.js
@@ -16,12 +16,13 @@
 import React from "react";
 import {connect} from "react-redux";
 // Actions
-import {authenticate, cancel, getOperationData, init, updateFormData} from "../actions/tokenAuthActions";
+import {authenticateOnline, cancel, getOperationData, initOnline} from "../actions/tokenAuthOnlineActions";
 // Components
 import OperationDetail from "./operationDetail";
+import TokenOffline from "./tokenAuthOffline";
+import TokenOnline from "./tokenAuthOnline";
+import Spinner from 'react-spin';
 import {Panel} from "react-bootstrap";
-// i18n
-import {FormattedMessage} from "react-intl";
 
 const stompClient = require('../websocket-client');
 
@@ -48,12 +49,11 @@ export default class Token extends React.Component {
         this.setAuthorized = this.setAuthorized.bind(this);
         this.isAuthorized = this.isAuthorized.bind(this);
         this.handleCancel = this.handleCancel.bind(this);
-        this.handleSwitchToQRCode = this.handleSwitchToQRCode.bind(this);
-        this.switchToQRCode = this.switchToQRCode.bind(this);
         this.cancelAuthorization = this.cancelAuthorization.bind(this);
         this.setUpdateTimeout = this.setUpdateTimeout.bind(this);
         this.getUpdateTimeout = this.getUpdateTimeout.bind(this);
         this.disconnect = this.disconnect.bind(this);
+        this.setOfflineMode = this.setOfflineMode.bind(this);
         this.state = {
             initialized: false,
             webSocketInitialized: false,
@@ -61,7 +61,8 @@ export default class Token extends React.Component {
             authorized: false,
             authorizationCanceled: false,
             updateTimeout: null,
-            disconnected: false
+            disconnected: false,
+            offlineModeEnabled: null
         };
     }
 
@@ -77,7 +78,7 @@ export default class Token extends React.Component {
         const setInitialized = this.setInitialized;
         const dispatch = this.props.dispatch;
         const update = this.update;
-        dispatch(init(function(initSucceeded) {
+        dispatch(initOnline(function(initSucceeded) {
             if (initSucceeded) {
                 setInitialized(true);
                 // continue only when init() succeeds - when push message is delivered
@@ -116,7 +117,7 @@ export default class Token extends React.Component {
             setAuthorizationInProgress(true);
             // Keep trying to authenticate every 3s using polling. This is a fallback mechanism in case
             // authorization by WebSockets fails completely (e.g. network issues).
-            this.props.dispatch(authenticate(function (b) {
+            this.props.dispatch(authenticateOnline(function (b) {
                 if (b) {
                     const timeout = setTimeout(function () {
                         update();
@@ -192,7 +193,7 @@ export default class Token extends React.Component {
         // Mark authorization in progress to lock calling of the authenticate() method. This prevents duplicate calls
         // of the authenticate() method.
         setAuthorizationInProgress(true);
-        this.props.dispatch(authenticate(function (b) {
+        this.props.dispatch(authenticateOnline(function (b) {
             if (!b) {
                 // Authorization was completed successfully.
                 setAuthorized(true);
@@ -206,17 +207,6 @@ export default class Token extends React.Component {
         event.preventDefault();
         this.disconnect();
         this.props.dispatch(cancel());
-    }
-
-    handleSwitchToQRCode(event) {
-        event.preventDefault();
-        this.disconnect();
-        const switchToQRCode = this.switchToQRCode;
-        // update form data - enable offline mode, when page is refreshed user selection is remembered
-        this.props.dispatch(updateFormData(this.props.context.formData, function () {
-            // change screen after formData are stored
-            switchToQRCode();
-        }));
     }
 
     disconnect() {
@@ -235,11 +225,8 @@ export default class Token extends React.Component {
         this.setState({disconnected: true});
     }
 
-    switchToQRCode() {
-        this.props.dispatch({
-            type: "SHOW_SCREEN_QR_CODE",
-            payload: {}
-        });
+    setOfflineMode(enabled) {
+        this.setState({offlineModeEnabled: enabled});
     }
 
     componentWillReceiveProps(props) {
@@ -254,6 +241,16 @@ export default class Token extends React.Component {
                 this.setState({webSocketInitialized: true});
             }
         }
+        if (props.context.formData) {
+            // When page is loading it is unknown whether offlineMode is enabled or not (this.state.offlineModeEnabled = null).
+            // Once formData is received it can be decided whether offline mode is enabled or not (via formData.userInput.offlineModeEnabled).
+            // When user clicks the offline mode link, the formData on server is updated and switch to offline mode is done immediately by offlineModeCallback.
+            if (props.context.formData.userInput.offlineModeEnabled) {
+                this.setOfflineMode(true);
+            } else {
+                this.setOfflineMode(false)
+            }
+        }
     }
 
     render() {
@@ -262,23 +259,17 @@ export default class Token extends React.Component {
                 <form>
                     <Panel>
                         <OperationDetail/>
-                        <div className="auth-actions">
-                            <div className="attributes">
-                                <div className="image mtoken"></div>
+                        {(this.state.offlineModeEnabled != null) ? (
+                            <div>
+                                {(this.state.offlineModeEnabled) ? (
+                                    <TokenOffline cancelCallback={this.handleCancel}/>
+                                ) : (
+                                    <TokenOnline cancelCallback={this.handleCancel} offlineModeCallback={this.setOfflineMode}/>
+                                )}
                             </div>
-                            <div className="attributes">
-                                <div className="font-small message-information">
-                                    <FormattedMessage id="message.token.offline"/><br/>
-                                    <a href="#" onClick={this.handleSwitchToQRCode}><FormattedMessage
-                                        id="message.token.offline.link"/></a>
-                                </div>
-                            </div>
-                            <div className="attribute row">
-                                <a href="#" onClick={this.handleCancel} className="btn btn-lg btn-default">
-                                    <FormattedMessage id="operation.cancel"/>
-                                </a>
-                            </div>
-                        </div>
+                        ) : (
+                            <Spinner/>
+                        )}
                     </Panel>
                 </form>
             </div>

--- a/powerauth-webflow/src/main/js/components/tokenAuth.js
+++ b/powerauth-webflow/src/main/js/components/tokenAuth.js
@@ -248,7 +248,7 @@ export default class Token extends React.Component {
             if (props.context.formData.userInput.offlineModeEnabled) {
                 this.setOfflineMode(true);
             } else {
-                this.setOfflineMode(false)
+                this.setOfflineMode(false);
             }
         }
     }

--- a/powerauth-webflow/src/main/js/components/tokenAuthOffline.js
+++ b/powerauth-webflow/src/main/js/components/tokenAuthOffline.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Lime - HighTech Solutions s.r.o.
+ * Copyright 2017 Lime - HighTech Solutions s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,9 @@
 import React from "react";
 import {connect} from "react-redux";
 // Actions
-import {authenticate, cancel, changeActivation, getOperationData, initQRCode} from "../actions/qrCodeAuthActions";
+import {authenticateOffline, changeActivation, initOffline} from "../actions/tokenAuthOfflineActions";
 // Components
-import OperationDetail from "./operationDetail";
-import {FormGroup, Panel} from "react-bootstrap";
+import {FormGroup} from "react-bootstrap";
 import Spinner from 'react-spin';
 // i18n
 import {FormattedMessage} from "react-intl";
@@ -34,7 +33,7 @@ import ActivationSelect from "./activationSelect";
         context: store.dispatching.context
     }
 })
-export default class QRCode extends React.Component {
+export default class TokenOffline extends React.Component {
 
     constructor() {
         super();
@@ -46,7 +45,6 @@ export default class QRCode extends React.Component {
         this.resolveChosenActivation = this.resolveChosenActivation.bind(this);
         this.handleActivationChoice = this.handleActivationChoice.bind(this);
         this.handleAuthCodeChange = this.handleAuthCodeChange.bind(this);
-        this.handleCancel = this.handleCancel.bind(this);
         this.handleSubmit = this.handleSubmit.bind(this);
         this.state = {authCode: '', activations: null, chosenActivation: null, nonce: null, dataHash: null};
     }
@@ -56,8 +54,7 @@ export default class QRCode extends React.Component {
     }
 
     init() {
-        this.props.dispatch(initQRCode(null));
-        this.props.dispatch(getOperationData());
+        this.props.dispatch(initOffline(null));
     }
 
     componentWillReceiveProps(props) {
@@ -77,7 +74,7 @@ export default class QRCode extends React.Component {
         }
         if (activations !== undefined && activations.length>0) {
             this.storeActivations(activations);
-            if (this.props.context.formData.userInput.chosenActivationId) {
+            if (props.context.formData.userInput.chosenActivationId) {
                 this.resolveChosenActivation(activations)
             } else {
                 this.storeChosenActivation(chosenActivation);
@@ -112,56 +109,45 @@ export default class QRCode extends React.Component {
     handleActivationChoice(activation) {
         this.setState({chosenActivation: activation});
         this.props.dispatch(changeActivation(activation));
-        this.props.dispatch(initQRCode(activation.activationId));
+        this.props.dispatch(initOffline(activation.activationId));
     }
 
     handleAuthCodeChange(event) {
         this.setState({authCode: event.target.value});
     }
 
-
-    handleCancel(event) {
-        this.props.dispatch(cancel());
-    }
-
     handleSubmit(event) {
         // prevent regular form submission
         event.preventDefault();
-        this.props.dispatch(authenticate(this.state.chosenActivation.activationId, this.state.authCode, this.state.nonce, this.state.dataHash));
+        this.props.dispatch(authenticateOffline(this.state.chosenActivation.activationId, this.state.authCode, this.state.nonce, this.state.dataHash));
     }
 
     render() {
         return (
-            <div id="operation">
-                <form onSubmit={this.handleSubmit}>
-                    <Panel>
-                        <OperationDetail/>
+            <div>
 
-                        {(this.state.activations && this.state.chosenActivation) ? (
-                            <div>
-                                <div className="row attribute col-sm-6 key">
-                                    <FormattedMessage id="qrCode.device"/>
-                                </div>
-                                <ActivationSelect
-                                    activations={this.state.activations}
-                                    chosenActivation={this.state.chosenActivation}
-                                    choiceDisabled={this.state.activations.length<2}
-                                    callback={this.handleActivationChoice}
-                                />
-                            </div>
-                        ) : (
-                            <Spinner/>
-                        )}
+                {(this.state.activations && this.state.chosenActivation) ? (
+                    <div>
+                        <div className="row attribute col-sm-6 key">
+                            <FormattedMessage id="qrCode.device"/>
+                        </div>
+                        <ActivationSelect
+                            activations={this.state.activations}
+                            chosenActivation={this.state.chosenActivation}
+                            choiceDisabled={this.state.activations.length<2}
+                            callback={this.handleActivationChoice}
+                        />
+                    </div>
+                ) : (
+                    <Spinner/>
+                )}
 
-                        {(this.props.context.qrCode) ? (
-                            <img src={"data:image/png;" + this.props.context.qrCode}/>
-                        ) : (
-                            <Spinner/>
-                        )}
-
+                {(this.props.context.qrCode) ? (
+                    <div>
+                        <img src={"data:image/png;" + this.props.context.qrCode}/>
                         {(this.props.context.message) ? (
                             <FormGroup
-                                className={(this.props.context.error ? "message-error" : "message-information" )}>
+                                className={(this.props.context.error ? "message-error" : "message-information")}>
                                 <FormattedMessage id={this.props.context.message}/>
                             </FormGroup>
                         ) : (
@@ -175,15 +161,20 @@ export default class QRCode extends React.Component {
                         <br/>
                         <input autoFocus type="text" value={this.state.authCode} onChange={this.handleAuthCodeChange}/>
                         <br/><br/>
-                        <a href="#" onClick={this.handleCancel} className="btn btn-lg btn-default">
-                            <FormattedMessage id="operation.cancel"/>
-                        </a>
-                        <a href="#" onClick={this.handleSubmit} className="btn btn-lg btn-default">
-                            <FormattedMessage id="operation.confirm"/>
-                        </a>
-                    </Panel>
-                </form>
-                {this.props.context.loading ? <Spinner/> : undefined}
+                        <div className="attribute row">
+                            <a href="#" onClick={this.props.cancelCallback} className="btn btn-lg btn-default">
+                                <FormattedMessage id="operation.cancel"/>
+                            </a>
+                        </div>
+                        <div className="attribute row">
+                            <a href="#" onClick={this.handleSubmit} className="btn btn-lg btn-default">
+                                <FormattedMessage id="operation.confirm"/>
+                            </a>
+                        </div>
+                    </div>
+                ) : (
+                    <Spinner/>
+                )}
             </div>
         )
     }

--- a/powerauth-webflow/src/main/js/components/tokenAuthOffline.js
+++ b/powerauth-webflow/src/main/js/components/tokenAuthOffline.js
@@ -38,15 +38,18 @@ export default class TokenOffline extends React.Component {
     constructor() {
         super();
         this.init = this.init.bind(this);
+        this.storeQRCode = this.storeQRCode.bind(this);
         this.storeNonce = this.storeNonce.bind(this);
         this.storeDataHash = this.storeDataHash.bind(this);
         this.storeActivations = this.storeActivations.bind(this);
         this.storeChosenActivation = this.storeChosenActivation.bind(this);
+        this.storeError = this.storeError.bind(this);
+        this.storeMessage = this.storeMessage.bind(this);
         this.resolveChosenActivation = this.resolveChosenActivation.bind(this);
         this.handleActivationChoice = this.handleActivationChoice.bind(this);
         this.handleAuthCodeChange = this.handleAuthCodeChange.bind(this);
         this.handleSubmit = this.handleSubmit.bind(this);
-        this.state = {authCode: '', activations: null, chosenActivation: null, nonce: null, dataHash: null};
+        this.state = {authCode: '', activations: null, chosenActivation: null, qrCode: null, nonce: null, dataHash: null, error: null, message: null};
     }
 
     componentWillMount() {
@@ -59,13 +62,25 @@ export default class TokenOffline extends React.Component {
 
     componentWillReceiveProps(props) {
         if (!props.context.init) {
+            // store message and error into component state because online mode reloads context frequently due to polling
+            if (props.context.error !== undefined) {
+                this.storeError(props.context.error);
+            }
+            if (props.context.message !== undefined) {
+                this.storeMessage(props.context.message);
+            }
             return;
         }
+        // offline mode initialization
         props.context.init = false;
+        const qrCode = props.context.qrCode;
         const nonce = props.context.nonce;
         const dataHash = props.context.dataHash;
         const chosenActivation = props.context.chosenActivation;
         const activations = props.context.activations;
+        if (qrCode !== undefined) {
+            this.storeQRCode(qrCode);
+        }
         if (nonce !== undefined) {
             this.storeNonce(nonce);
         }
@@ -82,6 +97,10 @@ export default class TokenOffline extends React.Component {
         }
     }
 
+    storeQRCode(qrCodeReceived) {
+        this.setState({qrCode: qrCodeReceived});
+    }
+
     storeNonce(nonceReceived) {
         this.setState({nonce: nonceReceived});
     }
@@ -96,6 +115,14 @@ export default class TokenOffline extends React.Component {
 
     storeChosenActivation(chosenActivation) {
         this.setState({chosenActivation: chosenActivation});
+    }
+
+    storeError(errorReceived) {
+        this.setState({error: errorReceived});
+    }
+
+    storeMessage(messageReceived) {
+        this.setState({message: messageReceived});
     }
 
     resolveChosenActivation(activations, chosenActivationId) {
@@ -142,13 +169,13 @@ export default class TokenOffline extends React.Component {
                     <Spinner/>
                 )}
 
-                {(this.props.context.qrCode) ? (
+                {(this.state.qrCode) ? (
                     <div>
-                        <img src={"data:image/png;" + this.props.context.qrCode}/>
-                        {(this.props.context.message) ? (
+                        <img src={"data:image/png;" + this.state.qrCode}/>
+                        {(this.state.message) ? (
                             <FormGroup
-                                className={(this.props.context.error ? "message-error" : "message-information")}>
-                                <FormattedMessage id={this.props.context.message}/>
+                                className={(this.state.error ? "message-error" : "message-information")}>
+                                <FormattedMessage id={this.state.message}/>
                             </FormGroup>
                         ) : (
                             <FormGroup

--- a/powerauth-webflow/src/main/js/components/tokenAuthOnline.js
+++ b/powerauth-webflow/src/main/js/components/tokenAuthOnline.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from "react";
+import {connect} from "react-redux";
+// Actions
+import {updateFormData} from "../actions/tokenAuthOnlineActions";
+// i18n
+import {FormattedMessage} from "react-intl";
+
+
+/**
+ * Operation component displays the operation data to the user.
+ */
+@connect((store) => {
+    return {
+        context: store.dispatching.context
+    }
+})
+export default class TokenOnline extends React.Component {
+
+    constructor() {
+        super();
+        this.handleSwitchToOfflineMode = this.handleSwitchToOfflineMode.bind(this);
+    }
+
+    handleSwitchToOfflineMode(event) {
+        event.preventDefault();
+        const offlineModeCallback = this.props.offlineModeCallback;
+        // set the offline mode userInput
+        this.props.context.formData.userInput.offlineModeEnabled = true;
+        // save updated form data in the backend
+        this.props.dispatch(updateFormData(this.props.context.formData, function () {
+            // update Token component state - switch to offline mode immediately
+            offlineModeCallback(true);
+        }));
+    }
+
+    render() {
+        return (
+            <div className="auth-actions">
+                <div className="attributes">
+                    <div className="image mtoken"/>
+                </div>
+                <div className="attributes">
+                    <div className="font-small message-information">
+                        <FormattedMessage id="message.token.offline"/><br/>
+                        <a href="#" onClick={this.handleSwitchToOfflineMode}><FormattedMessage
+                            id="message.token.offline.link"/></a>
+                    </div>
+                </div>
+                <div className="attribute row">
+                    <a href="#" onClick={this.props.cancelCallback} className="btn btn-lg btn-default">
+                        <FormattedMessage id="operation.cancel"/>
+                    </a>
+                </div>
+            </div>
+        )
+    }
+}

--- a/powerauth-webflow/src/main/js/reducers/dispatchingReducer.js
+++ b/powerauth-webflow/src/main/js/reducers/dispatchingReducer.js
@@ -17,13 +17,6 @@ export default function reducer(state = {currentScreen: "SCREEN_START_HANDSHAKE"
                 context: mergeContext(action.type, state.context, action.payload)
             };
         }
-        case "SHOW_SCREEN_QR_CODE": {
-            return {
-                ...state,
-                currentScreen: "SCREEN_QR_CODE",
-                context: mergeContext(action.type, state.context, action.payload)
-            };
-        }
         case "SHOW_SCREEN_SMS": {
             return {
                 ...state,
@@ -84,15 +77,10 @@ function mergeContext(actionType, oldContext, newContext) {
             break;
         case "SHOW_SCREEN_TOKEN":
             mergeData(oldContext, newContext);
-            setOfflineMode(newContext, false);
+            mergeQRCode(oldContext, newContext);
             break;
         case "SHOW_SCREEN_SMS":
             mergeData(oldContext, newContext);
-            break;
-        case "SHOW_SCREEN_QR_CODE":
-            mergeQRCode(oldContext, newContext);
-            mergeData(oldContext, newContext);
-            setOfflineMode(newContext, true);
             break;
         case "CHANGE_BANK_ACCOUNT":
             changeBankAccount(oldContext, newContext);
@@ -130,10 +118,6 @@ function mergeQRCode(oldContext, newContext) {
     if (oldContext.qrCode !== undefined && newContext.qrCode === undefined) {
         newContext.qrCode = oldContext.qrCode;
     }
-}
-
-function setOfflineMode(newContext, offlineModeEnabled) {
-    newContext.formData.userInput.offlineModeEnabled = offlineModeEnabled;
 }
 
 function changeBankAccount(oldContext, newContext) {

--- a/powerauth-webflow/src/main/js/reducers/dispatchingReducer.js
+++ b/powerauth-webflow/src/main/js/reducers/dispatchingReducer.js
@@ -77,7 +77,6 @@ function mergeContext(actionType, oldContext, newContext) {
             break;
         case "SHOW_SCREEN_TOKEN":
             mergeData(oldContext, newContext);
-            mergeQRCode(oldContext, newContext);
             break;
         case "SHOW_SCREEN_SMS":
             mergeData(oldContext, newContext);
@@ -110,13 +109,6 @@ function mergeAuthMethods(oldContext, newContext) {
     // authMethods need to remain in context
     if (oldContext.authMethods !== undefined && newContext.authMethods === undefined) {
         newContext.authMethods = oldContext.authMethods;
-    }
-}
-
-function mergeQRCode(oldContext, newContext) {
-    // QR code needs to remain in context
-    if (oldContext.qrCode !== undefined && newContext.qrCode === undefined) {
-        newContext.qrCode = oldContext.qrCode;
     }
 }
 


### PR DESCRIPTION
This change is quite complex and will require testing - we should check whether Mobile Token online mode and offline modes still work same as before and it is possible to use online mode on the offline mode page without any side effects.

Changelog:
- Both online and offline modes are now combined in the UI, in the offline screen user can perform online Mobile Token authorization
- SHOW_SCREEN_QR_CODE was replaced by SHOW_SCREEN_TOKEN, Mobile Token is now one UI component with 2 sub-components (online and offline)
- Endpoint '/api/auth/qr' renamed to '/api/auth/token/offline'
- Better names for online and offline mode classes, components and methods to avoid confusion after combining both modes
- Updated logic in MobileToken web controller for resolving history which takes into account operation changes caused both by Mobile API and offline mode