### PR TITLE
Fix #136: Verify activationId in mobile API requests of Mobile Token step

### DIFF
--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileAppApiController.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileAppApiController.java
@@ -15,14 +15,14 @@ import io.getlime.security.powerauth.lib.nextstep.model.response.UpdateOperation
 import io.getlime.security.powerauth.lib.webflow.authentication.controller.AuthMethodController;
 import io.getlime.security.powerauth.lib.webflow.authentication.exception.AuthStepException;
 import io.getlime.security.powerauth.lib.webflow.authentication.mtoken.configuration.PushServiceConfiguration;
-import io.getlime.security.powerauth.lib.webflow.authentication.mtoken.exception.InvalidRequestObjectException;
-import io.getlime.security.powerauth.lib.webflow.authentication.mtoken.exception.PushRegistrationFailedException;
+import io.getlime.security.powerauth.lib.webflow.authentication.mtoken.exception.*;
 import io.getlime.security.powerauth.lib.webflow.authentication.mtoken.model.request.MobileTokenAuthenticationRequest;
 import io.getlime.security.powerauth.lib.webflow.authentication.mtoken.model.request.MobileTokenCancelOperationRequest;
 import io.getlime.security.powerauth.lib.webflow.authentication.mtoken.model.request.MobileTokenPushRegisterRequest;
 import io.getlime.security.powerauth.lib.webflow.authentication.mtoken.model.request.MobileTokenSignRequest;
 import io.getlime.security.powerauth.lib.webflow.authentication.mtoken.model.response.MobileTokenAuthenticationResponse;
 import io.getlime.security.powerauth.lib.webflow.authentication.mtoken.service.WebSocketMessageService;
+import io.getlime.security.powerauth.lib.webflow.authentication.service.AuthMethodQueryService;
 import io.getlime.security.powerauth.rest.api.base.authentication.PowerAuthApiAuthentication;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 import io.getlime.security.powerauth.rest.api.spring.annotation.PowerAuth;
@@ -34,6 +34,8 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * This controller presents endpoints that are consumed by the native mobile app,
@@ -46,16 +48,17 @@ import java.util.List;
 public class MobileAppApiController extends AuthMethodController<MobileTokenAuthenticationRequest, MobileTokenAuthenticationResponse, AuthStepException> {
 
     private final WebSocketMessageService webSocketMessageService;
-
     private final PushServiceConfiguration configuration;
-
     private final PushServerClient pushServerClient;
+    private final AuthMethodQueryService authMethodQueryService;
+
 
     @Autowired
-    public MobileAppApiController(WebSocketMessageService webSocketMessageService, PushServiceConfiguration configuration, PushServerClient pushServerClient) {
+    public MobileAppApiController(WebSocketMessageService webSocketMessageService, PushServiceConfiguration configuration, PushServerClient pushServerClient, AuthMethodQueryService authMethodQueryService) {
         this.webSocketMessageService = webSocketMessageService;
         this.configuration = configuration;
         this.pushServerClient = pushServerClient;
+        this.authMethodQueryService = authMethodQueryService;
     }
 
     @Override
@@ -63,12 +66,20 @@ public class MobileAppApiController extends AuthMethodController<MobileTokenAuth
         return AuthMethod.POWERAUTH_TOKEN;
     }
 
+    /**
+     * Register device for push notifications.
+     * @param request Push registration request.
+     * @param apiAuthentication API authentication.
+     * @return Push registration response.
+     * @throws PowerAuthAuthenticationException Thrown when push registration fails.
+     * @throws PushRegistrationFailedException Thrown when push registration fails due to client exception.
+     */
     @RequestMapping(value = "/push/register", method = RequestMethod.POST)
     @PowerAuth(resourceId = "/push/register", signatureType = {PowerAuthSignatureTypes.POSSESSION})
-    public @ResponseBody Response registerDevice(@RequestBody ObjectRequest<MobileTokenPushRegisterRequest> request, PowerAuthApiAuthentication apiAuthentication) throws PowerAuthAuthenticationException, PushRegistrationFailedException {
+    public @ResponseBody Response registerDevice(@RequestBody ObjectRequest<MobileTokenPushRegisterRequest> request, PowerAuthApiAuthentication apiAuthentication) throws PowerAuthAuthenticationException {
 
         if (request.getRequestObject() == null) {
-            throw new PushRegistrationFailedException();
+            throw new InvalidRequestObjectException();
         }
 
         // Get the values from the request
@@ -78,8 +89,15 @@ public class MobileAppApiController extends AuthMethodController<MobileTokenAuth
         // Check if the context is authenticated - if it is, add activation ID.
         // This assures that the activation is assigned with a correct device.
         String activationId = null;
+        String userId = null;
         if (apiAuthentication != null) {
             activationId = apiAuthentication.getActivationId();
+            userId = apiAuthentication.getUserId();
+        }
+
+        // Verify that the activation ID from context matches configured activation ID for given user.
+        if (!verifyActivationId(activationId, userId)) {
+            throw new InvalidActivationException();
         }
 
         // Register the device and return response
@@ -92,38 +110,66 @@ public class MobileAppApiController extends AuthMethodController<MobileTokenAuth
             if (result) {
                 return new Response();
             } else {
-                throw new PowerAuthAuthenticationException("Authentication failed: Unable to register for push messages");
+                throw new PushRegistrationFailedException();
             }
         } catch (PushServerClientException ex) {
             throw new PushRegistrationFailedException();
         }
     }
 
+    /**
+     * List pending operations for Mobile Token authorization.
+     * @param apiAuthentication API authentication.
+     * @return Response with list of pending operations.
+     * @throws PowerAuthAuthenticationException Thrown when loading of pending operations fails.
+     */
     @RequestMapping(value = "/operation/list", method = RequestMethod.POST)
     @PowerAuth(resourceId = "/operation/list", signatureType = {PowerAuthSignatureTypes.POSSESSION})
     public @ResponseBody ObjectResponse<List<GetOperationDetailResponse>> getOperationList(PowerAuthApiAuthentication apiAuthentication) throws PowerAuthAuthenticationException {
 
         if (apiAuthentication != null && apiAuthentication.getUserId() != null) {
+            String activationId = apiAuthentication.getActivationId();
             String userId = apiAuthentication.getUserId();
+
+            // Verify that the activation ID from context matches configured activation ID for given user.
+            if (!verifyActivationId(activationId, userId)) {
+                throw new InvalidActivationException();
+            }
+
             final List<GetOperationDetailResponse> operationList = getOperationListForUser(userId);
             return new ObjectResponse<>(operationList);
         } else {
-            throw new PowerAuthAuthenticationException("Authentication failed: Unable to download pending operations");
+            throw new PendingOperationListFailedException();
         }
 
     }
 
+    /**
+     * Authorize an operation using Mobile Token.
+     * @param request Mobile Token authorization request.
+     * @param apiAuthentication API authentication.
+     * @return Authorization response.
+     * @throws NextStepServiceException Thrown when next step client fails.
+     * @throws PowerAuthAuthenticationException Thrown when authentication fails.
+     * @throws InvalidRequestObjectException Thrown when requestObject is invalid.
+     */
     @RequestMapping(value = "/operation/authorize", method = RequestMethod.POST)
     @PowerAuth(resourceId = "/operation/authorize")
-    public @ResponseBody Response verifySignature(@RequestBody ObjectRequest<MobileTokenSignRequest> request, PowerAuthApiAuthentication apiAuthentication) throws NextStepServiceException, PowerAuthAuthenticationException, InvalidRequestObjectException {
+    public @ResponseBody Response verifySignature(@RequestBody ObjectRequest<MobileTokenSignRequest> request, PowerAuthApiAuthentication apiAuthentication) throws NextStepServiceException, PowerAuthAuthenticationException {
 
         if (request.getRequestObject() == null) {
             throw new InvalidRequestObjectException();
         }
 
         if (apiAuthentication != null && apiAuthentication.getUserId() != null) {
+            String activationId = apiAuthentication.getActivationId();
             String userId = apiAuthentication.getUserId();
             String operationId = request.getRequestObject().getId();
+
+            // Verify that the activation ID from context matches configured activation ID for given user.
+            if (!verifyActivationId(activationId, userId)) {
+                throw new InvalidActivationException();
+            }
 
             final GetOperationDetailResponse operation = getOperation(operationId);
             if (operation.getOperationData().equals(request.getRequestObject().getData()) && operation.getUserId().equals(apiAuthentication.getUserId())) {
@@ -131,30 +177,62 @@ public class MobileAppApiController extends AuthMethodController<MobileTokenAuth
                 webSocketMessageService.notifyAuthorizationComplete(operationId, updateOperationResponse.getResult());
                 return new Response();
             } else {
-                throw new PowerAuthAuthenticationException("Authentication failed: Unable to sign operation");
+                throw new SignatureVerificationException();
             }
         } else {
-            throw new PowerAuthAuthenticationException("Authentication failed: Unable to sign operation");
+            throw new SignatureVerificationException();
         }
 
     }
 
+    /**
+     * Cancel an operation.
+     * @param request Cancel request.
+     * @param apiAuthentication API authentication.
+     * @return Cancel response.
+     * @throws PowerAuthAuthenticationException Thrown when operation could not be canceled.
+     * @throws NextStepServiceException Thrown when next step client fails.
+     */
     @RequestMapping(value = "/operation/cancel", method = RequestMethod.POST)
     @PowerAuth(resourceId = "/operation/cancel", signatureType = {PowerAuthSignatureTypes.POSSESSION})
     public @ResponseBody Object cancelOperation(@RequestBody ObjectRequest<MobileTokenCancelOperationRequest> request, PowerAuthApiAuthentication apiAuthentication) throws PowerAuthAuthenticationException, NextStepServiceException {
 
         if (apiAuthentication != null && apiAuthentication.getUserId() != null) {
+            String activationId = apiAuthentication.getActivationId();
             String userId = apiAuthentication.getUserId();
             String operationId = request.getRequestObject().getId();
+
+            // Verify that the activation ID from context matches configured activation ID for given user.
+            if (!verifyActivationId(activationId, userId)) {
+                throw new InvalidActivationException();
+            }
 
             final UpdateOperationResponse updateOperationResponse = cancelAuthorization(operationId, userId, OperationCancelReason.valueOf(request.getRequestObject().getReason()), null);
             webSocketMessageService.notifyAuthorizationComplete(operationId, updateOperationResponse.getResult());
             return new Response();
 
         } else {
-            throw new PowerAuthAuthenticationException("Authentication failed: Unable to cancel pending operation");
+            throw new CancelOperationFailedException();
         }
 
+    }
+
+    /**
+     * Verifies that activation ID matches configured activation ID for given user.
+     * @param activationId Checked activation ID.
+     * @param userId User ID.
+     * @return Whether activation ID matches configured activation ID.
+     */
+    private boolean verifyActivationId(String activationId, String userId) {
+        try {
+            String configuredActivationId = authMethodQueryService.getActivationIdForMobileTokenAuthMethod(userId);
+            if (configuredActivationId != null && configuredActivationId.equals(activationId)) {
+                return true;
+            }
+        } catch (NextStepServiceException ex) {
+            Logger.getLogger(this.getClass().getName()).log(Level.SEVERE, "Could not verify activationId", ex);
+        }
+        return false;
     }
 
 }

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/exception/CancelOperationFailedException.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/exception/CancelOperationFailedException.java
@@ -1,0 +1,15 @@
+package io.getlime.security.powerauth.lib.webflow.authentication.mtoken.exception;
+
+import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
+
+/**
+ * Exception thrown when operation could not be canceled.
+ *
+ * @author Roman Strobl, roman.strobl@lime-company.eu
+ */
+public class CancelOperationFailedException extends PowerAuthAuthenticationException {
+
+    public CancelOperationFailedException() {
+        super("Unable to cancel operation in Mobile Token API component.");
+    }
+}

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/exception/InvalidActivationException.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/exception/InvalidActivationException.java
@@ -1,0 +1,15 @@
+package io.getlime.security.powerauth.lib.webflow.authentication.mtoken.exception;
+
+import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
+
+/**
+ * Exception thrown when activation is invalid.
+ *
+ * @author Roman Strobl, roman.strobl@lime-company.eu
+ */
+public class InvalidActivationException extends PowerAuthAuthenticationException {
+
+    public InvalidActivationException() {
+        super("Invalid activation found in Mobile Token API component.");
+    }
+}

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/exception/InvalidRequestObjectException.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/exception/InvalidRequestObjectException.java
@@ -1,9 +1,13 @@
 package io.getlime.security.powerauth.lib.webflow.authentication.mtoken.exception;
 
+import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
+
 /**
+ * Exception thrown when request object is invalid.
+ *
  * @author Petr Dvorak, petr@lime-company.eu
  */
-public class InvalidRequestObjectException extends Exception {
+public class InvalidRequestObjectException extends PowerAuthAuthenticationException {
 
     public InvalidRequestObjectException() {
         super("Invalid request object sent to Mobile Token API component.");

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/exception/MobileTokenApiExceptionResolver.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/exception/MobileTokenApiExceptionResolver.java
@@ -39,7 +39,7 @@ import java.util.logging.Logger;
 public class MobileTokenApiExceptionResolver {
 
     /**
-     * Exception handler for push registration related exception..
+     * Exception handler for push registration related exception.
      *
      * @return Response with error details.
      */
@@ -47,11 +47,11 @@ public class MobileTokenApiExceptionResolver {
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public @ResponseBody ErrorResponse handlePushRegistrationException(Throwable t) {
         Logger.getLogger(this.getClass().getName()).log(Level.SEVERE, "Error occurred in Mobile Token API component", t);
-        return new ErrorResponse(new Error());
+        return new ErrorResponse(new Error("PUSH_REGISTRATION_FAILED", t.getMessage()));
     }
 
     /**
-     * Exception handler for push registration related exception..
+     * Exception handler for invalid request object exception.
      *
      * @return Response with error details.
      */
@@ -59,7 +59,54 @@ public class MobileTokenApiExceptionResolver {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public @ResponseBody ErrorResponse handleInvalidRequestObjectException(Throwable t) {
         Logger.getLogger(this.getClass().getName()).log(Level.SEVERE, "Error occurred in Mobile Token API component", t);
-        return new ErrorResponse(new Error());
+        return new ErrorResponse(new Error("INVALID_REQUEST", t.getMessage()));
     }
 
+    /**
+     * Exception handler for invalid activation exception.
+     *
+     * @return Response with error details.
+     */
+    @ExceptionHandler(InvalidActivationException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public @ResponseBody ErrorResponse handleInvalidValidationException(Throwable t) {
+        Logger.getLogger(this.getClass().getName()).log(Level.SEVERE, "Error occurred in Mobile Token API component", t);
+        return new ErrorResponse(new Error("INVALID_ACTIVATION", t.getMessage()));
+    }
+
+    /**
+     * Exception handler for cancel operation failed exception.
+     *
+     * @return Response with error details.
+     */
+    @ExceptionHandler(CancelOperationFailedException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public @ResponseBody ErrorResponse handleOperationCancelFailedException(Throwable t) {
+        Logger.getLogger(this.getClass().getName()).log(Level.SEVERE, "Error occurred in Mobile Token API component", t);
+        return new ErrorResponse(new Error("OPERATION_CANCEL_FAILED", t.getMessage()));
+    }
+
+    /**
+     * Exception handler for pending operation list exception.
+     *
+     * @return Response with error details.
+     */
+    @ExceptionHandler(PendingOperationListFailedException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public @ResponseBody ErrorResponse handlePendingOperationListFailedException(Throwable t) {
+        Logger.getLogger(this.getClass().getName()).log(Level.SEVERE, "Error occurred in Mobile Token API component", t);
+        return new ErrorResponse(new Error("OPERATION_LIST_FAILED", t.getMessage()));
+    }
+
+    /**
+     * Exception handler for signature verification exception.
+     *
+     * @return Response with error details.
+     */
+    @ExceptionHandler(SignatureVerificationException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public @ResponseBody ErrorResponse handleSignatureVerificationException(Throwable t) {
+        Logger.getLogger(this.getClass().getName()).log(Level.SEVERE, "Error occurred in Mobile Token API component", t);
+        return new ErrorResponse(new Error("SIGNATURE_VERIFICATION_FAILED", t.getMessage()));
+    }
 }

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/exception/PendingOperationListFailedException.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/exception/PendingOperationListFailedException.java
@@ -1,0 +1,15 @@
+package io.getlime.security.powerauth.lib.webflow.authentication.mtoken.exception;
+
+import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
+
+/**
+ * Exception thrown when list of pending operations could not be loaded.
+ *
+ * @author Roman Strobl, roman.strobl@lime-company.eu
+ */
+public class PendingOperationListFailedException extends PowerAuthAuthenticationException {
+
+    public PendingOperationListFailedException() {
+        super("Unable to download pending operations in Mobile Token API component.");
+    }
+}

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/exception/PushRegistrationFailedException.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/exception/PushRegistrationFailedException.java
@@ -1,12 +1,16 @@
 package io.getlime.security.powerauth.lib.webflow.authentication.mtoken.exception;
 
+import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
+
 /**
+ * Exception thrown when push registration fails.
+ *
  * @author Petr Dvorak, petr@lime-company.eu
  */
-public class PushRegistrationFailedException extends Exception {
+public class PushRegistrationFailedException extends PowerAuthAuthenticationException {
 
     public PushRegistrationFailedException() {
-        super("Push registration failed.");
+        super("Push registration failed in Mobile Token API component.");
     }
 
 }

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/exception/QRCodeExceptionResolver.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/exception/QRCodeExceptionResolver.java
@@ -45,7 +45,7 @@ public class QRCodeExceptionResolver {
      */
     @ExceptionHandler(QRCodeInvalidDataException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public @ResponseBody ErrorResponse handleInvalidRequestObjectException(QRCodeInvalidDataException ex) {
+    public @ResponseBody ErrorResponse handleQRCodeInvalidDataException(QRCodeInvalidDataException ex) {
         Logger.getLogger(this.getClass().getName()).log(Level.SEVERE, "Error occurred in Mobile Token API component", ex);
         Error error = new Error(Error.Code.ERROR_GENERIC, ex.getMessage());
         return new ErrorResponse(error);

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/exception/SignatureVerificationException.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/exception/SignatureVerificationException.java
@@ -1,0 +1,15 @@
+package io.getlime.security.powerauth.lib.webflow.authentication.mtoken.exception;
+
+import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
+
+/**
+ * Exception thrown when signature could not be verified.
+ *
+ * @author Roman Strobl, roman.strobl@lime-company.eu
+ */
+public class SignatureVerificationException extends PowerAuthAuthenticationException {
+
+    public SignatureVerificationException() {
+        super("Unable to verify signature in Mobile Token API component.");
+    }
+}


### PR DESCRIPTION
Partial resolution for #145: Use Error class for Exceptions in Mobile API