### PR TITLE
Fix #101: NullPointerException at mobile token /authenticate method

### DIFF
--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileTokenOnlineController.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileTokenOnlineController.java
@@ -74,6 +74,9 @@ public class MobileTokenOnlineController extends AuthMethodController<MobileToke
     @Override
     protected String authenticate(MobileTokenAuthenticationRequest request) throws AuthStepException {
         final GetOperationDetailResponse operation = getOperation();
+        if (operation == null) {
+            throw new AuthStepException("operation.notAvailable", new NullPointerException());
+        }
         if (!isAuthMethodAvailable(operation)) {
             // when AuthMethod is disabled authenticate() call should always fail
             return null;
@@ -96,6 +99,14 @@ public class MobileTokenOnlineController extends AuthMethodController<MobileToke
     @RequestMapping(value = "/init", method = RequestMethod.POST)
     public @ResponseBody MobileTokenInitResponse initPushMessage() throws NextStepServiceException {
         final GetOperationDetailResponse operation = getOperation();
+
+        if (operation == null) {
+            // when operation is no longer available (e.g. expired), auth method should fail
+            final MobileTokenInitResponse response = new MobileTokenInitResponse();
+            response.setResult(AuthStepResult.AUTH_METHOD_FAILED);
+            response.setMessage("operation.notAvailable");
+            return response;
+        }
 
         if (!isAuthMethodAvailable(operation)) {
             // when AuthMethod is disabled, operation should fail
@@ -177,6 +188,9 @@ public class MobileTokenOnlineController extends AuthMethodController<MobileToke
     public @ResponseBody MobileTokenAuthenticationResponse checkOperationStatus(@RequestBody MobileTokenAuthenticationRequest request) {
 
         final GetOperationDetailResponse operation = getOperation();
+        if (operation == null) {
+            return operationNotAvailable();
+        }
 
         if (operation.isExpired()) {
             // handle operation expiration
@@ -256,7 +270,11 @@ public class MobileTokenOnlineController extends AuthMethodController<MobileToke
     @RequestMapping(value = "/cancel", method = RequestMethod.POST)
     public @ResponseBody MobileTokenAuthenticationResponse cancelAuthentication() {
         try {
-            cancelAuthorization(getOperation().getOperationId(), null, OperationCancelReason.UNKNOWN, null);
+            GetOperationDetailResponse operation = getOperation();
+            if (operation == null) {
+                return operationNotAvailable();
+            }
+            cancelAuthorization(operation.getOperationId(), null, OperationCancelReason.UNKNOWN, null);
             final MobileTokenAuthenticationResponse response = new MobileTokenAuthenticationResponse();
             response.setResult(AuthStepResult.CANCELED);
             response.setMessage("operation.canceled");
@@ -267,6 +285,14 @@ public class MobileTokenOnlineController extends AuthMethodController<MobileToke
             response.setMessage(e.getMessage());
             return response;
         }
+    }
+
+    private MobileTokenAuthenticationResponse operationNotAvailable() {
+        // when operation is no longer available (e.g. expired), auth method should fail
+        final MobileTokenAuthenticationResponse response = new MobileTokenAuthenticationResponse();
+        response.setResult(AuthStepResult.AUTH_METHOD_FAILED);
+        response.setMessage("operation.notAvailable");
+        return response;
     }
 
 }

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/controller/AuthMethodController.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/controller/AuthMethodController.java
@@ -294,9 +294,14 @@ public abstract class AuthMethodController<T extends AuthStepRequest, R extends 
             String userId = authenticate(request);
             UpdateOperationResponse responseObject;
             if (userId == null) {
+                GetOperationDetailResponse operation = getOperation();
+                if (operation == null) {
+                    // operation is not available
+                    return provider.failedAuthentication(null, "operation.notAvailable");
+                }
                 // user was not authenticated - fail authorization
                 authenticationManagementService.clearContext();
-                responseObject = failAuthorization(getOperation().getOperationId(), null, null);
+                responseObject = failAuthorization(operation.getOperationId(), null, null);
             } else {
                 // user was authenticated - complete authorization
                 String operationId = authenticationManagementService.updateAuthenticationWithUserId(userId);
@@ -331,6 +336,9 @@ public abstract class AuthMethodController<T extends AuthStepRequest, R extends 
     protected void authenticateCurrentBrowserSession() {
         authenticationManagementService.authenticateCurrentSession();
         final GetOperationDetailResponse operation = getOperation();
+        if (operation == null) {
+            throw new IllegalStateException("operation.notAvailable");
+        }
         if (AuthResult.DONE.equals(operation.getResult())) {
             authenticationManagementService.pendingAuthenticationToAuthentication();
         }

--- a/powerauth-webflow-i18n/src/main/resources/static/resources/messages_cs.properties
+++ b/powerauth-webflow-i18n/src/main/resources/static/resources/messages_cs.properties
@@ -39,6 +39,7 @@ method.smsKey=SMS klíč
 method.disabled=Ověřovací metoda není dostupná.
 operation.timeout=Vypršel časový limit pro operaci.
 operation.canceled=Operace byla zrušena uživatelem.
+operation.notAvailable=Operace již není dostupná.
 operation.noMethod=Operaci nelze ověřit, protože není k dispozici žádná autentizační metoda.
 operation.confirmationTextChoice=Vyberte způsob potvrzení:
 operation.confirmationText=Potvrďte operaci:

--- a/powerauth-webflow-i18n/src/main/resources/static/resources/messages_en.properties
+++ b/powerauth-webflow-i18n/src/main/resources/static/resources/messages_en.properties
@@ -39,6 +39,7 @@ method.smsKey=SMS Key
 method.disabled=Authentication method is disabled.
 operation.timeout=Operation has timed out.
 operation.canceled=Operation has been canceled by the user.
+operation.notAvailable=Operation is no longer available.
 operation.confirmationTextChoice=Choose the confirmation method:
 operation.confirmationText=Confirm the operation:
 operation.noMethod=Operation cannot be confirmed, because there is no authorization method available.


### PR DESCRIPTION
All cases when operation is not available (is null) should be handled now