### PR TITLE
Fix #180: Mobile token authentication does not expire

### DIFF
--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/StepResolutionService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/StepResolutionService.java
@@ -134,6 +134,8 @@ public class StepResolutionService {
         }
         if (operation.isExpired()) {
             // Operation fails in case it is expired.
+            // Fail authentication method.
+            request.setAuthStepResult(AuthStepResult.AUTH_METHOD_FAILED);
             // Response expiration time matches operation expiration to avoid extending expiration time of the operation.
             response.setTimestampExpires(operation.getTimestampExpires());
             response.setResult(AuthResult.FAILED);

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileAppApiController.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileAppApiController.java
@@ -169,6 +169,9 @@ public class MobileAppApiController extends AuthMethodController<MobileTokenAuth
             }
 
             final GetOperationDetailResponse operation = getOperation(operationId);
+            if (operation.isExpired()) {
+                throw new OperationExpiredException();
+            }
             if (operation.getOperationData().equals(request.getRequestObject().getData()) && operation.getUserId().equals(apiAuthentication.getUserId())) {
                 final UpdateOperationResponse updateOperationResponse = authorize(operationId, userId);
                 webSocketMessageService.notifyAuthorizationComplete(operationId, updateOperationResponse.getResult());

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/exception/MobileTokenApiExceptionResolver.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/exception/MobileTokenApiExceptionResolver.java
@@ -136,4 +136,16 @@ public class MobileTokenApiExceptionResolver {
         Logger.getLogger(this.getClass().getName()).log(Level.SEVERE, "Error occurred in Mobile Token API component", t);
         return new ErrorResponse(new Error("OPERATION_ALREADY_FAILED", t.getMessage()));
     }
+
+    /**
+     * Exception handler for expiration.
+     *
+     * @return Response with error details.
+     */
+    @ExceptionHandler(OperationExpiredException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public @ResponseBody ErrorResponse handleOperationExpiredException(Throwable t) {
+        Logger.getLogger(this.getClass().getName()).log(Level.SEVERE, "Error occurred in Mobile Token API component", t);
+        return new ErrorResponse(new Error("OPERATION_EXPIRED", t.getMessage()));
+    }
 }

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/exception/OperationExpiredException.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/exception/OperationExpiredException.java
@@ -1,0 +1,15 @@
+package io.getlime.security.powerauth.lib.webflow.authentication.mtoken.exception;
+
+import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
+
+/**
+ * Exception thrown when operation is expired.
+ *
+ * @author Roman Strobl, roman.strobl@lime-company.eu
+ */
+public class OperationExpiredException extends PowerAuthAuthenticationException {
+
+    public OperationExpiredException() {
+        super("Operation expired in Mobile Token API component.");
+    }
+}

--- a/powerauth-webflow/src/main/js/actions/smsAuthActions.js
+++ b/powerauth-webflow/src/main/js/actions/smsAuthActions.js
@@ -79,7 +79,7 @@ export function authenticate(userAuthCode) {
                 }
                 case 'AUTH_FAILED': {
                     // handle timeout - action can not succeed anymore, show error
-                    if (response.data.message === "authentication.timeout") {
+                    if (response.data.message === "operation.timeout") {
                         dispatchAction(dispatch, response);
                         break;
                     }

--- a/powerauth-webflow/src/main/js/actions/tokenAuthOfflineActions.js
+++ b/powerauth-webflow/src/main/js/actions/tokenAuthOfflineActions.js
@@ -108,7 +108,7 @@ export function authenticateOffline(activationId, authCode, nonce, dataHash) {
                 }
                 case 'AUTH_FAILED': {
                     // handle timeout - action can not succeed anymore, show error
-                    if (response.data.message === "authentication.timeout") {
+                    if (response.data.message === "operation.timeout") {
                         dispatchAction(dispatch, response);
                         break;
                     }

--- a/powerauth-webflow/src/main/js/actions/tokenAuthOnlineActions.js
+++ b/powerauth-webflow/src/main/js/actions/tokenAuthOnlineActions.js
@@ -74,7 +74,7 @@ export function authenticateOnline(callback) {
                         break;
                     }
                     // handle timeout - action can not succeed anymore, show error
-                    if (response.data.message === "authentication.timeout") {
+                    if (response.data.message === "operation.timeout") {
                         dispatchAction(dispatch, response);
                         break;
                     }

--- a/powerauth-webflow/src/main/js/actions/usernamePasswordAuthActions.js
+++ b/powerauth-webflow/src/main/js/actions/usernamePasswordAuthActions.js
@@ -22,7 +22,7 @@ export function authenticate(username, password) {
                 }
                 case 'AUTH_FAILED': {
                     // handle timeout - login action can not succeed anymore, do not show login screen, show error instead
-                    if (response.data.message === "authentication.timeout") {
+                    if (response.data.message === "operation.timeout") {
                         dispatchAction(dispatch, response);
                         break;
                     }


### PR DESCRIPTION
There were three problems:
* Obsolete strings for detecting timeout in the UI causing the UI not to respond to operation expiration
* Mobile API could confirm expired operations - authentication is not done at this point, so expiration needs to be checked explicitly
* Added the newer AUTH_METHOD_FAILED AuthStepResult for consistency when resolving the next step
