### PR TITLE
Fix #200: Data Adapter service must account for networking errors

### DIFF
--- a/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/entity/DataAdapterError.java
+++ b/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/entity/DataAdapterError.java
@@ -35,6 +35,7 @@ public class DataAdapterError extends Error {
         public static final String AUTHENTICATION_FAILED = "AUTHENTICATION_FAILED";
         public static final String SMS_AUTHORIZATION_FAILED = "SMS_AUTHORIZATION_FAILED";
         public static final String INPUT_INVALID = "INPUT_INVALID";
+        public static final String REMOTE_ERROR = "REMOTE_ERROR";
     }
 
     /**

--- a/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/lib/dataadapter/api/DataAdapter.java
+++ b/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/lib/dataadapter/api/DataAdapter.java
@@ -16,6 +16,7 @@
 package io.getlime.security.powerauth.lib.dataadapter.api;
 
 import io.getlime.security.powerauth.lib.dataadapter.exception.AuthenticationFailedException;
+import io.getlime.security.powerauth.lib.dataadapter.exception.DataAdapterRemoteException;
 import io.getlime.security.powerauth.lib.dataadapter.exception.SMSAuthorizationFailedException;
 import io.getlime.security.powerauth.lib.dataadapter.exception.UserNotFoundException;
 import io.getlime.security.powerauth.lib.dataadapter.model.entity.BankAccount;
@@ -39,7 +40,7 @@ public interface DataAdapter {
      * @param password Password for user authentication.
      * @throws AuthenticationFailedException Thrown when authentication fails.
      */
-    UserDetailResponse authenticateUser(String username, String password) throws AuthenticationFailedException;
+    UserDetailResponse authenticateUser(String username, String password) throws DataAdapterRemoteException, AuthenticationFailedException;
 
     /**
      * Fetch user detail for given user.
@@ -47,7 +48,7 @@ public interface DataAdapter {
      * @return Response with user details.
      * @throws UserNotFoundException Thrown when user does not exist.
      */
-    UserDetailResponse fetchUserDetail(String userId) throws UserNotFoundException;
+    UserDetailResponse fetchUserDetail(String userId) throws DataAdapterRemoteException, UserNotFoundException;
 
     /**
      * Fetch bank account details for given user.
@@ -56,7 +57,7 @@ public interface DataAdapter {
      * @return Response with bank account details.
      * @throws UserNotFoundException Thrown when user does not exist.
      */
-    List<BankAccount> fetchBankAccounts(String userId, String operationId) throws UserNotFoundException;
+    List<BankAccount> fetchBankAccounts(String userId, String operationId) throws DataAdapterRemoteException, UserNotFoundException;
 
     /**
      * Receive notification about formData change.
@@ -64,7 +65,7 @@ public interface DataAdapter {
      * @param operationId Operation ID.
      * @param formDataChange FormData change.
      */
-    void formDataChangedNotification(String userId, String operationId, FormDataChange formDataChange);
+    void formDataChangedNotification(String userId, String operationId, FormDataChange formDataChange) throws DataAdapterRemoteException;
 
     /**
      * Receive notification about operation change.
@@ -72,7 +73,7 @@ public interface DataAdapter {
      * @param operationId Operation ID.
      * @param operationChange Operation change.
      */
-    void operationChangedNotification(String userId, String operationId, OperationChange operationChange);
+    void operationChangedNotification(String userId, String operationId, OperationChange operationChange) throws DataAdapterRemoteException;
 
     /**
      * Send an authorization SMS with generated OTP.
@@ -80,6 +81,6 @@ public interface DataAdapter {
      * @param messageText Text of SMS message.
      * @throws SMSAuthorizationFailedException Thrown when message could not be created.
      */
-    void sendAuthorizationSMS(String userId, String messageText) throws SMSAuthorizationFailedException;
+    void sendAuthorizationSMS(String userId, String messageText) throws DataAdapterRemoteException, SMSAuthorizationFailedException;
 
 }

--- a/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/lib/dataadapter/controller/AuthenticationController.java
+++ b/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/lib/dataadapter/controller/AuthenticationController.java
@@ -19,6 +19,7 @@ import io.getlime.core.rest.model.base.request.ObjectRequest;
 import io.getlime.core.rest.model.base.response.ObjectResponse;
 import io.getlime.security.powerauth.lib.dataadapter.api.DataAdapter;
 import io.getlime.security.powerauth.lib.dataadapter.exception.AuthenticationFailedException;
+import io.getlime.security.powerauth.lib.dataadapter.exception.DataAdapterRemoteException;
 import io.getlime.security.powerauth.lib.dataadapter.exception.UserNotFoundException;
 import io.getlime.security.powerauth.lib.dataadapter.impl.validation.AuthenticationRequestValidator;
 import io.getlime.security.powerauth.lib.dataadapter.model.request.AuthenticationRequest;
@@ -72,7 +73,7 @@ public class AuthenticationController {
      * @throws MethodArgumentNotValidException In case form parameters are not valid.
      */
     @RequestMapping(value = "/authenticate", method = RequestMethod.POST)
-    public @ResponseBody ObjectResponse<AuthenticationResponse> authenticate(@Valid @RequestBody ObjectRequest<AuthenticationRequest> request, BindingResult result) throws MethodArgumentNotValidException, AuthenticationFailedException {
+    public @ResponseBody ObjectResponse<AuthenticationResponse> authenticate(@Valid @RequestBody ObjectRequest<AuthenticationRequest> request, BindingResult result) throws MethodArgumentNotValidException, DataAdapterRemoteException, AuthenticationFailedException {
         if (result.hasErrors()) {
             // getEnclosingMethod() on new object returns a reference to current method
             MethodParameter methodParam = new MethodParameter(new Object(){}.getClass().getEnclosingMethod(),0);
@@ -93,7 +94,7 @@ public class AuthenticationController {
      * @return Response with user details.
      */
     @RequestMapping(value = "/info", method = RequestMethod.POST)
-    public @ResponseBody ObjectResponse<UserDetailResponse> fetchUserDetail(@RequestBody ObjectRequest<UserDetailRequest> request) throws MethodArgumentNotValidException, UserNotFoundException {
+    public @ResponseBody ObjectResponse<UserDetailResponse> fetchUserDetail(@RequestBody ObjectRequest<UserDetailRequest> request) throws DataAdapterRemoteException, UserNotFoundException {
         UserDetailRequest userDetailRequest = request.getRequestObject();
         String userId = userDetailRequest.getId();
         UserDetailResponse response = dataAdapter.fetchUserDetail(userId);

--- a/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/lib/dataadapter/controller/BankAccountController.java
+++ b/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/lib/dataadapter/controller/BankAccountController.java
@@ -18,13 +18,13 @@ package io.getlime.security.powerauth.lib.dataadapter.controller;
 import io.getlime.core.rest.model.base.request.ObjectRequest;
 import io.getlime.core.rest.model.base.response.ObjectResponse;
 import io.getlime.security.powerauth.lib.dataadapter.api.DataAdapter;
+import io.getlime.security.powerauth.lib.dataadapter.exception.DataAdapterRemoteException;
 import io.getlime.security.powerauth.lib.dataadapter.exception.UserNotFoundException;
 import io.getlime.security.powerauth.lib.dataadapter.model.entity.BankAccount;
 import io.getlime.security.powerauth.lib.dataadapter.model.request.BankAccountListRequest;
 import io.getlime.security.powerauth.lib.dataadapter.model.response.BankAccountListResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -55,7 +55,7 @@ public class BankAccountController {
      * @return Response with user details.
      */
     @RequestMapping(value = "/list", method = RequestMethod.POST)
-    public @ResponseBody ObjectResponse<BankAccountListResponse> fetchBankAccounts(@RequestBody ObjectRequest<BankAccountListRequest> request) throws MethodArgumentNotValidException, UserNotFoundException {
+    public @ResponseBody ObjectResponse<BankAccountListResponse> fetchBankAccounts(@RequestBody ObjectRequest<BankAccountListRequest> request) throws DataAdapterRemoteException, UserNotFoundException {
         BankAccountListRequest bankAccountListRequest = request.getRequestObject();
         String userId = bankAccountListRequest.getUserId();
         String operationId = bankAccountListRequest.getOperationId();

--- a/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/lib/dataadapter/controller/FormDataChangeController.java
+++ b/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/lib/dataadapter/controller/FormDataChangeController.java
@@ -18,6 +18,7 @@ package io.getlime.security.powerauth.lib.dataadapter.controller;
 import io.getlime.core.rest.model.base.request.ObjectRequest;
 import io.getlime.core.rest.model.base.response.ObjectResponse;
 import io.getlime.security.powerauth.lib.dataadapter.api.DataAdapter;
+import io.getlime.security.powerauth.lib.dataadapter.exception.DataAdapterRemoteException;
 import io.getlime.security.powerauth.lib.dataadapter.model.entity.FormDataChange;
 import io.getlime.security.powerauth.lib.dataadapter.model.request.FormDataChangeNotificationRequest;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,7 +51,7 @@ public class FormDataChangeController {
      * @return Object response.
      */
     @RequestMapping(value = "/change", method = RequestMethod.POST)
-    public @ResponseBody ObjectResponse formDataChangedNotification(@RequestBody ObjectRequest<FormDataChangeNotificationRequest> request) {
+    public @ResponseBody ObjectResponse formDataChangedNotification(@RequestBody ObjectRequest<FormDataChangeNotificationRequest> request) throws DataAdapterRemoteException {
         FormDataChangeNotificationRequest notification = request.getRequestObject();
         String userId = notification.getUserId();
         String operationId = notification.getOperationId();

--- a/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/lib/dataadapter/controller/OperationChangeController.java
+++ b/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/lib/dataadapter/controller/OperationChangeController.java
@@ -18,6 +18,7 @@ package io.getlime.security.powerauth.lib.dataadapter.controller;
 import io.getlime.core.rest.model.base.request.ObjectRequest;
 import io.getlime.core.rest.model.base.response.ObjectResponse;
 import io.getlime.security.powerauth.lib.dataadapter.api.DataAdapter;
+import io.getlime.security.powerauth.lib.dataadapter.exception.DataAdapterRemoteException;
 import io.getlime.security.powerauth.lib.dataadapter.model.entity.OperationChange;
 import io.getlime.security.powerauth.lib.dataadapter.model.request.OperationChangeNotificationRequest;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,7 +51,7 @@ public class OperationChangeController {
      * @return Object response.
      */
     @RequestMapping(value = "/change", method = RequestMethod.POST)
-    public @ResponseBody ObjectResponse operationChangedNotification(@RequestBody ObjectRequest<OperationChangeNotificationRequest> request) {
+    public @ResponseBody ObjectResponse operationChangedNotification(@RequestBody ObjectRequest<OperationChangeNotificationRequest> request) throws DataAdapterRemoteException {
         OperationChangeNotificationRequest notification = request.getRequestObject();
         String userId = notification.getUserId();
         String operationId = notification.getOperationId();

--- a/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/lib/dataadapter/controller/SMSAuthorizationController.java
+++ b/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/lib/dataadapter/controller/SMSAuthorizationController.java
@@ -18,6 +18,7 @@ package io.getlime.security.powerauth.lib.dataadapter.controller;
 import io.getlime.core.rest.model.base.request.ObjectRequest;
 import io.getlime.core.rest.model.base.response.ObjectResponse;
 import io.getlime.security.powerauth.lib.dataadapter.api.DataAdapter;
+import io.getlime.security.powerauth.lib.dataadapter.exception.DataAdapterRemoteException;
 import io.getlime.security.powerauth.lib.dataadapter.exception.SMSAuthorizationFailedException;
 import io.getlime.security.powerauth.lib.dataadapter.impl.validation.CreateSMSAuthorizationRequestValidator;
 import io.getlime.security.powerauth.lib.dataadapter.model.request.CreateSMSAuthorizationRequest;
@@ -74,7 +75,7 @@ public class SMSAuthorizationController {
      * @return Response with message ID.
      */
     @RequestMapping(value = "create", method = RequestMethod.POST)
-    public @ResponseBody ObjectResponse<CreateSMSAuthorizationResponse> create(@Valid @RequestBody ObjectRequest<CreateSMSAuthorizationRequest> request, BindingResult result) throws MethodArgumentNotValidException, SMSAuthorizationFailedException {
+    public @ResponseBody ObjectResponse<CreateSMSAuthorizationResponse> create(@Valid @RequestBody ObjectRequest<CreateSMSAuthorizationRequest> request, BindingResult result) throws MethodArgumentNotValidException, DataAdapterRemoteException, SMSAuthorizationFailedException {
         if (result.hasErrors()) {
             // getEnclosingMethod() on new object returns a reference to current method
             MethodParameter methodParam = new MethodParameter(new Object(){}.getClass().getEnclosingMethod(),0);

--- a/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/lib/dataadapter/exception/DataAdapterRemoteException.java
+++ b/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/lib/dataadapter/exception/DataAdapterRemoteException.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.lib.dataadapter.exception;
+
+/**
+ * Exception for unexpected remote communication errors.
+ * @author Roman Strobl, roman.strobl@lime-company.eu
+ */
+public class DataAdapterRemoteException extends Exception {
+
+    /**
+     * Default constructor.
+     */
+    public DataAdapterRemoteException() {
+    }
+
+    /**
+     * Constructor with message.
+     *
+     * @param message Message.
+     */
+    public DataAdapterRemoteException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructor with message and cause.
+     *
+     * @param message Message.
+     * @param cause   Cause, original exception.
+     */
+    public DataAdapterRemoteException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructor with cause.
+     *
+     * @param cause Cause, original exception.
+     */
+    public DataAdapterRemoteException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/lib/dataadapter/exception/DefaultExceptionResolver.java
+++ b/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/lib/dataadapter/exception/DefaultExceptionResolver.java
@@ -145,4 +145,17 @@ public class DefaultExceptionResolver {
         return new ErrorResponse(error);
     }
 
+    /**
+     * Handling of exceptions occurring during communication with remote backends.
+     *
+     * @return Response with error information.
+     */
+    @ExceptionHandler(DataAdapterRemoteException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public @ResponseBody ErrorResponse handleDataAdapterRemoteException(DataAdapterRemoteException ex) {
+        Logger.getLogger(this.getClass().getName()).log(Level.SEVERE, "Error occurred while communicating with remote system", ex);
+        DataAdapterError error = new DataAdapterError(DataAdapterError.Code.REMOTE_ERROR, "error.remote");
+        return new ErrorResponse(error);
+    }
+
 }

--- a/powerauth-webflow-i18n/src/main/resources/static/resources/messages_cs.properties
+++ b/powerauth-webflow-i18n/src/main/resources/static/resources/messages_cs.properties
@@ -3,6 +3,7 @@ error.sessionExpired=Vaše relace byla ukončena.
 error.sessionTerminated=Relace byla ukončena.
 error.invalidRequest=Žádost není korektní.
 error.noAuthMethod=Nebyla nalezena žádná vhodná autentizační metoda.
+error.remote=Nastala chyba při komunikaci se vzdáleným systémem.
 error.unknown=Nastala neznámá chyba.
 login.signIn=Přihlásit se
 login.cancel=Zrušit

--- a/powerauth-webflow-i18n/src/main/resources/static/resources/messages_en.properties
+++ b/powerauth-webflow-i18n/src/main/resources/static/resources/messages_en.properties
@@ -3,6 +3,7 @@ error.sessionExpired=Your session has expired.
 error.sessionTerminated=Session has been terminated.
 error.invalidRequest=Invalid request.
 error.noAuthMethod=No authentication method is available to serve the request.
+error.remote=Error occurred during communication with remote system.
 error.unknown=Unknown error occurred.
 login.signIn=Sign In
 login.cancel=Cancel


### PR DESCRIPTION
I added the DataAdapterRemoteException. The error message is not propagated into user interface (a more generic remote error text is displayed), however the exception is logged.