### PR TITLE
Fix #210: Error when reading SMS salt with Oracle

### DIFF
--- a/powerauth-webflow-docs/sql/oracle/create_schema.sql
+++ b/powerauth-webflow-docs/sql/oracle/create_schema.sql
@@ -136,7 +136,7 @@ CREATE TABLE da_sms_authorization (
   user_id              VARCHAR(256),
   operation_name       VARCHAR(32),
   authorization_code   VARCHAR(32),
-  salt                 RAW(16),
+  salt                 BLOB,
   message_text         CLOB,
   verify_request_count INTEGER,
   verified             NUMBER(1) DEFAULT 0,


### PR DESCRIPTION
Let's use BLOB instead of RAW(16), it resolves the issue I had. Furthermore we use BLOB in many other columns, so it is better for consistency.