### PR TITLE
Fix #224: Error when initiating operation with unset operation ID 

### DIFF
--- a/powerauth-webflow-authentication-init/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/init/model/response/InitOperationResponse.java
+++ b/powerauth-webflow-authentication-init/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/init/model/response/InitOperationResponse.java
@@ -27,4 +27,13 @@ import io.getlime.security.powerauth.lib.webflow.authentication.base.AuthStepRes
  */
 public class InitOperationResponse extends AuthStepResponse {
 
+    private String operationHash;
+
+    public String getOperationHash() {
+        return operationHash;
+    }
+
+    public void setOperationHash(String operationHash) {
+        this.operationHash = operationHash;
+    }
 }

--- a/powerauth-webflow/src/main/js/actions/startHandshakeActions.js
+++ b/powerauth-webflow/src/main/js/actions/startHandshakeActions.js
@@ -8,6 +8,10 @@ export function authenticate() {
                 'X-OPERATION-HASH': operationHash,
             }
         }).then((response) => {
+            // save operation hash in case the operation has been just initialized (default operation)
+            if (operationHash === null) {
+                operationHash = response.data.operationHash;
+            }
             dispatchAction(dispatch, response);
         }).catch((error) => {
             dispatchError(dispatch, error);


### PR DESCRIPTION
Allow null operation in INIT authentication method for default operations.

Transfer operation hash to the client for default operations which are initialized in INIT step. This is done for concurrency checks - the initial operation ID is null, so the client receives the operation hash after operation registration in INIT authentication method instead of having the operation hash from the very beginning.