### PR TITLE
Fix #226: Exception in Mobile API due to old version of Guava library

### DIFF
--- a/powerauth-webflow-authentication-mtoken/pom.xml
+++ b/powerauth-webflow-authentication-mtoken/pom.xml
@@ -38,6 +38,12 @@
             <groupId>org.springframework.ws</groupId>
             <artifactId>spring-ws-security</artifactId>
             <version>2.2.4.RELEASE</version> <!-- 2.3.0 seems a bit buggy, SWS-972 and SWS-972 -->
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.getlime.security</groupId>

--- a/powerauth-webflow/pom.xml
+++ b/powerauth-webflow/pom.xml
@@ -116,6 +116,12 @@
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger2</artifactId>
             <version>2.7.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.springfox</groupId>


### PR DESCRIPTION
Libraries springfox-swagger2 and spring-ws-security depend on old version of Guava which was causing problems during validation of Mobile API requests. Guava is excluded for these two libraries.