### PR TITLE
Fix #227: Invalid operation in authorize endpoint of Mobile API

### DIFF
--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/controller/AuthMethodController.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/controller/AuthMethodController.java
@@ -446,10 +446,8 @@ public abstract class AuthMethodController<T extends AuthStepRequest, R extends 
             // verify operation hash
             String clientOperationHash = request.getHeader("X-OPERATION-HASH");
             String currentOperationHash = operationSessionService.generateOperationHash(operation.getOperationId());
-            if (clientOperationHash == null) {
-                throw new AuthStepException("operation.invalid", new NullPointerException());
-            }
-            if (!clientOperationHash.equals(currentOperationHash)) {
+            // mobile API clients do not send operation hash - when operation hash is missing, concurrency check is not performed
+            if (clientOperationHash != null && !clientOperationHash.equals(currentOperationHash)) {
                 throw new AuthStepException("operation.interrupted", new IllegalStateException());
             }
             // check steps for operations with AuthResult = CONTINUE, DONE and FAILED methods do not have steps

--- a/powerauth-webflow-i18n/src/main/resources/static/resources/messages_cs.properties
+++ b/powerauth-webflow-i18n/src/main/resources/static/resources/messages_cs.properties
@@ -48,7 +48,6 @@ operation.invalidChosenMethod=Vybraná ověřovací metoda není platná.
 operation.missingHistory=Není dostupná historie operace.
 operation.methodNotAvailable=Ověřovací metoda není dostupná.
 operation.interrupted=Operace byla přerušena novější operací.
-operation.invalid=Operace není validní.
 canceled.unknown=Operace byla zrušena z neznámého důvodu.
 canceled.incorrectData=Operace byla zrušena, protože obsahovala nesprávná data.
 canceled.unexpectedOperation=Operace byla zrušena, protože nebyla očekávána.

--- a/powerauth-webflow-i18n/src/main/resources/static/resources/messages_en.properties
+++ b/powerauth-webflow-i18n/src/main/resources/static/resources/messages_en.properties
@@ -48,7 +48,6 @@ operation.invalidChosenMethod=Chosen authentication method is not valid.
 operation.missingHistory=Operation history is not available.
 operation.methodNotAvailable=Authentication method is not available.
 operation.interrupted=Operation has been interrupted by a newer operation.
-operation.invalid=Operace is not valid.
 canceled.unknown=Operation has been canceled due to an unknown reason.
 canceled.incorrectData=Operation has been canceled because it contained incorrect data.
 canceled.unexpectedOperation=Operation has been canceled because it was not expected.


### PR DESCRIPTION
Concurrency check needs to be bypassed for Mobile API (it makes no sense there). So when operation hash is missing, concurrency check is skipped.