### PR TITLE
Fix #236: SMS message validator should be action independent

### DIFF
--- a/powerauth-data-adapter-client/src/main/java/io/getlime/security/powerauth/lib/dataadapter/client/DataAdapterClient.java
+++ b/powerauth-data-adapter-client/src/main/java/io/getlime/security/powerauth/lib/dataadapter/client/DataAdapterClient.java
@@ -205,12 +205,14 @@ public class DataAdapterClient {
      * Obtain bank account list for given user.
      *
      * @param userId User ID of the user for this request.
+     * @param operationName Operation name.
+     * @param operationId Operation ID.
      * @return A list of bank accounts for given user.
      */
-    public ObjectResponse<BankAccountListResponse> fetchBankAccounts(String userId, String operationId) throws DataAdapterClientErrorException {
+    public ObjectResponse<BankAccountListResponse> fetchBankAccounts(String userId, String operationName, String operationId) throws DataAdapterClientErrorException {
         try {
             // Exchange user details with data adapter.
-            BankAccountListRequest request = new BankAccountListRequest(userId, operationId);
+            BankAccountListRequest request = new BankAccountListRequest(userId, operationName, operationId);
             HttpHeaders headers = new HttpHeaders();
             headers.set("Accept-Language", LocaleContextHolder.getLocale().getLanguage());
             HttpEntity<ObjectRequest<BankAccountListRequest>> entity = new HttpEntity<>(new ObjectRequest<>(request), headers);

--- a/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/request/BankAccountListRequest.java
+++ b/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/request/BankAccountListRequest.java
@@ -24,6 +24,7 @@ package io.getlime.security.powerauth.lib.dataadapter.model.request;
 public class BankAccountListRequest {
 
     private String userId;
+    private String operationName;
     private String operationId;
 
     /**
@@ -35,9 +36,12 @@ public class BankAccountListRequest {
     /**
      * Constructor with user ID as a parameter.
      * @param userId User ID.
+     * @param operationName Operation name.
+     * @param operationId Operation ID.
      */
-    public BankAccountListRequest(String userId, String operationId) {
+    public BankAccountListRequest(String userId, String operationName, String operationId) {
         this.userId = userId;
+        this.operationName = operationName;
         this.operationId = operationId;
     }
 
@@ -55,6 +59,22 @@ public class BankAccountListRequest {
      */
     public void setUserId(String userId) {
         this.userId = userId;
+    }
+
+    /**
+     * Get operation name.
+     * @return Operation name.
+     */
+    public String getOperationName() {
+        return operationName;
+    }
+
+    /**
+     * Set operation name.
+     * @param operationName Operation name.
+     */
+    public void setOperationName(String operationName) {
+        this.operationName = operationName;
     }
 
     /**

--- a/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/lib/dataadapter/api/DataAdapter.java
+++ b/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/lib/dataadapter/api/DataAdapter.java
@@ -53,11 +53,12 @@ public interface DataAdapter {
     /**
      * Fetch bank account details for given user.
      * @param userId User ID.
+     * @param operationName Operation name.
      * @param operationId Operation ID.
      * @return Response with bank account details.
      * @throws UserNotFoundException Thrown when user does not exist.
      */
-    List<BankAccount> fetchBankAccounts(String userId, String operationId) throws DataAdapterRemoteException, UserNotFoundException;
+    List<BankAccount> fetchBankAccounts(String userId, String operationName, String operationId) throws DataAdapterRemoteException, UserNotFoundException;
 
     /**
      * Receive notification about formData change.

--- a/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/lib/dataadapter/controller/BankAccountController.java
+++ b/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/lib/dataadapter/controller/BankAccountController.java
@@ -58,8 +58,9 @@ public class BankAccountController {
     public @ResponseBody ObjectResponse<BankAccountListResponse> fetchBankAccounts(@RequestBody ObjectRequest<BankAccountListRequest> request) throws DataAdapterRemoteException, UserNotFoundException {
         BankAccountListRequest bankAccountListRequest = request.getRequestObject();
         String userId = bankAccountListRequest.getUserId();
+        String operationName = bankAccountListRequest.getOperationName();
         String operationId = bankAccountListRequest.getOperationId();
-        List<BankAccount> bankAccounts = dataAdapter.fetchBankAccounts(userId, operationId);
+        List<BankAccount> bankAccounts = dataAdapter.fetchBankAccounts(userId, operationName, operationId);
         BankAccountListResponse response = new BankAccountListResponse(userId, bankAccounts);
         return new ObjectResponse<>(response);
     }

--- a/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/lib/dataadapter/impl/service/DataAdapterService.java
+++ b/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/lib/dataadapter/impl/service/DataAdapterService.java
@@ -59,12 +59,17 @@ public class DataAdapterService implements DataAdapter {
     }
 
     @Override
-    public List<BankAccount> fetchBankAccounts(String userId, String operationId) throws UserNotFoundException {
+    public List<BankAccount> fetchBankAccounts(String userId, String operationName, String operationId) throws UserNotFoundException {
         // Fetch bank account list for given user here from the bank backend.
         // In case that user is not found, throw a UserNotFoundException.
         // Replace mock bank account data with real data loaded from the bank backend.
         // In case the bank account selection is disabled, return an empty list.
         List<BankAccount> bankAccounts = new ArrayList<>();
+
+        if (!"authorize_payment".equals(operationName)) {
+            // return empty list for operations other than authorize_payment
+            return bankAccounts;
+        }
 
         BankAccount bankAccount1 = new BankAccount();
         bankAccount1.setName("Běžný účet v CZK");

--- a/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/lib/dataadapter/impl/validation/CreateSMSAuthorizationRequestValidator.java
+++ b/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/lib/dataadapter/impl/validation/CreateSMSAuthorizationRequestValidator.java
@@ -69,24 +69,37 @@ public class CreateSMSAuthorizationRequestValidator implements Validator {
             errors.rejectValue("requestObject.operationName", "smsAuthorization.operationName.long");
         }
 
-        OperationAmountFieldAttribute amountAttribute = operationFormDataService.getAmount(authRequest.getOperationFormData());
-        BigDecimal amount = amountAttribute.getAmount();
-        String currency = amountAttribute.getCurrency();
-        String account = operationFormDataService.getAccount(authRequest.getOperationFormData());
+        if (operationName != null) {
+            switch (operationName) {
+                case "login":
+                    // no field validation required
+                    break;
+                case "authorize_payment":
+                    OperationAmountFieldAttribute amountAttribute = operationFormDataService.getAmount(authRequest.getOperationFormData());
+                    if (amountAttribute == null) {
+                        errors.rejectValue("requestObject.operationFormData", "smsAuthorization.amount.empty");
+                    } else {
+                        BigDecimal amount = amountAttribute.getAmount();
+                        String currency = amountAttribute.getCurrency();
 
-        if (amount == null) {
-            errors.rejectValue("requestObject.operationFormData", "smsAuthorization.amount.empty");
-        } else if (amount.doubleValue()<=0) {
-            errors.rejectValue("requestObject.operationFormData", "smsAuthorization.amount.invalid");
+                        if (amount == null) {
+                            errors.rejectValue("requestObject.operationFormData", "smsAuthorization.amount.empty");
+                        } else if (amount.doubleValue() <= 0) {
+                            errors.rejectValue("requestObject.operationFormData", "smsAuthorization.amount.invalid");
+                        }
+
+                        if (currency == null || currency.isEmpty()) {
+                            errors.rejectValue("requestObject.operationFormData", "smsAuthorization.currency.empty");
+                        }
+                    }
+                    String account = operationFormDataService.getAccount(authRequest.getOperationFormData());
+                    if (account == null || account.isEmpty()) {
+                        errors.rejectValue("requestObject.operationFormData", "smsAuthorization.account.empty");
+                    }
+                    break;
+                default:
+                    throw new IllegalStateException("Unsupported operation in validator: " + operationName);
+            }
         }
-
-        if (currency == null || currency.isEmpty()) {
-            errors.rejectValue("requestObject.operationFormData", "smsAuthorization.currency.empty");
-        }
-
-        if (account == null || account.isEmpty()) {
-            errors.rejectValue("requestObject.operationFormData", "smsAuthorization.account.empty");
-        }
-
     }
 }

--- a/powerauth-data-adapter/src/main/resources/static/resources/messages_cs.properties
+++ b/powerauth-data-adapter/src/main/resources/static/resources/messages_cs.properties
@@ -1,2 +1,3 @@
-sms-otp.text=Autorizační kód pro platbu {0} {1} na účet {2} je {3}.
+login.smsText=Autorizační kód pro přihlášení je {0}.
+authorize_payment.smsText=Autorizační kód pro platbu {0} {1} na účet {2} je {3}.
 operationReview.balanceTooLow=Nízký zůstatek na účtu

--- a/powerauth-data-adapter/src/main/resources/static/resources/messages_en.properties
+++ b/powerauth-data-adapter/src/main/resources/static/resources/messages_en.properties
@@ -1,2 +1,3 @@
-sms-otp.text=Authorization code for payment of {0} {1} to account {2} is {3}.
+login.smsText=Authorization code for login is {0}.
+authorize_payment.smsText=Authorization code for payment of {0} {1} to account {2} is {3}.
 operationReview.balanceTooLow=Low account balance

--- a/powerauth-webflow-authentication-operation-review/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/operation/controller/OperationReviewController.java
+++ b/powerauth-webflow-authentication-operation-review/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/operation/controller/OperationReviewController.java
@@ -187,7 +187,7 @@ public class OperationReviewController extends AuthMethodController<OperationRev
             // load dynamic data based on user id. For now dynamic data contains the bank account list,
             // however it can be easily extended in the future.
             try {
-                ObjectResponse<BankAccountListResponse> response = dataAdapterClient.fetchBankAccounts(operation.getUserId(), operation.getOperationId());
+                ObjectResponse<BankAccountListResponse> response = dataAdapterClient.fetchBankAccounts(operation.getUserId(), operation.getOperationName(), operation.getOperationId());
                 List<BankAccount> bankAccountEntities = response.getResponseObject().getBankAccounts();
                 List<BankAccountDetail> bankAccountDetails = convertBankAccountEntities(bankAccountEntities);
                 if (!bankAccountDetails.isEmpty()) {


### PR DESCRIPTION
Support for 2FA login in Data Adapter
Do not send bank account details for non-payment operations