### PR TITLE
Fix #262: Add version and compilation time to service status endpoint

### DIFF
--- a/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/response/ServiceStatusResponse.java
+++ b/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/response/ServiceStatusResponse.java
@@ -28,6 +28,8 @@ public class ServiceStatusResponse {
     private String applicationName;
     private String applicationDisplayName;
     private String applicationEnvironment;
+    private String version;
+    private Date buildTime;
     private Date timestamp;
 
     /**
@@ -76,6 +78,38 @@ public class ServiceStatusResponse {
      */
     public void setApplicationEnvironment(String applicationEnvironment) {
         this.applicationEnvironment = applicationEnvironment;
+    }
+
+    /**
+     * Get version.
+     * @return version.
+     */
+    public String getVersion() {
+        return version;
+    }
+
+    /**
+     * Set version.
+     * @param version Version.
+     */
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    /**
+     * Get build time.
+     * @return Build time.
+     */
+    public Date getBuildTime() {
+        return buildTime;
+    }
+
+    /**
+     * Set build time.
+     * @param buildTime Build time.
+     */
+    public void setBuildTime(Date buildTime) {
+        this.buildTime = buildTime;
     }
 
     /**

--- a/powerauth-data-adapter/pom.xml
+++ b/powerauth-data-adapter/pom.xml
@@ -80,6 +80,14 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>build-info</id>
+                        <goals>
+                            <goal>build-info</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/lib/dataadapter/controller/ServiceController.java
+++ b/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/lib/dataadapter/controller/ServiceController.java
@@ -20,6 +20,7 @@ import io.getlime.core.rest.model.base.response.ObjectResponse;
 import io.getlime.security.powerauth.lib.dataadapter.configuration.DataAdapterConfiguration;
 import io.getlime.security.powerauth.lib.dataadapter.model.response.ServiceStatusResponse;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.info.BuildProperties;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -37,14 +38,17 @@ import java.util.Date;
 public class ServiceController {
 
     private final DataAdapterConfiguration dataAdapterConfiguration;
+    private final BuildProperties buildProperties;
 
     /**
      * Controller constructor.
      * @param dataAdapterConfiguration Data adapter configuration.
+     * @param buildProperties Build info.
      */
     @Autowired
-    public ServiceController(DataAdapterConfiguration dataAdapterConfiguration) {
+    public ServiceController(DataAdapterConfiguration dataAdapterConfiguration, BuildProperties buildProperties) {
         this.dataAdapterConfiguration = dataAdapterConfiguration;
+        this.buildProperties = buildProperties;
     }
 
     /**
@@ -58,6 +62,8 @@ public class ServiceController {
         response.setApplicationDisplayName(dataAdapterConfiguration.getApplicationDisplayName());
         response.setApplicationEnvironment(dataAdapterConfiguration.getApplicationEnvironment());
         response.setTimestamp(new Date());
+        response.setVersion(buildProperties.getVersion());
+        response.setBuildTime(buildProperties.getTime());
         return new ObjectResponse<>(response);
     }
 }

--- a/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/response/ServiceStatusResponse.java
+++ b/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/response/ServiceStatusResponse.java
@@ -28,6 +28,8 @@ public class ServiceStatusResponse {
     private String applicationName;
     private String applicationDisplayName;
     private String applicationEnvironment;
+    private String version;
+    private Date buildTime;
     private Date timestamp;
 
     /**
@@ -76,6 +78,38 @@ public class ServiceStatusResponse {
      */
     public void setApplicationEnvironment(String applicationEnvironment) {
         this.applicationEnvironment = applicationEnvironment;
+    }
+
+    /**
+     * Get version.
+     * @return version.
+     */
+    public String getVersion() {
+        return version;
+    }
+
+    /**
+     * Set version.
+     * @param version Version.
+     */
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    /**
+     * Get build time.
+     * @return Build time.
+     */
+    public Date getBuildTime() {
+        return buildTime;
+    }
+
+    /**
+     * Set build time.
+     * @param buildTime Build time.
+     */
+    public void setBuildTime(Date buildTime) {
+        this.buildTime = buildTime;
     }
 
     /**

--- a/powerauth-nextstep/pom.xml
+++ b/powerauth-nextstep/pom.xml
@@ -77,6 +77,14 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>build-info</id>
+						<goals>
+							<goal>build-info</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/ServiceController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/ServiceController.java
@@ -20,6 +20,7 @@ import io.getlime.core.rest.model.base.response.ObjectResponse;
 import io.getlime.security.powerauth.app.nextstep.configuration.NextStepServerConfiguration;
 import io.getlime.security.powerauth.lib.nextstep.model.response.ServiceStatusResponse;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.info.BuildProperties;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -37,14 +38,17 @@ import java.util.Date;
 public class ServiceController {
 
     private final NextStepServerConfiguration nextStepServerConfiguration;
+    private final BuildProperties buildProperties;
 
     /**
      * Controller constructor.
      * @param nextStepServerConfiguration Next step server configuration.
+     * @param buildProperties Build info.
      */
     @Autowired
-    public ServiceController(NextStepServerConfiguration nextStepServerConfiguration) {
+    public ServiceController(NextStepServerConfiguration nextStepServerConfiguration, BuildProperties buildProperties) {
         this.nextStepServerConfiguration = nextStepServerConfiguration;
+        this.buildProperties = buildProperties;
     }
 
     /**
@@ -57,6 +61,8 @@ public class ServiceController {
         response.setApplicationName(nextStepServerConfiguration.getApplicationName());
         response.setApplicationDisplayName(nextStepServerConfiguration.getApplicationDisplayName());
         response.setApplicationEnvironment(nextStepServerConfiguration.getApplicationEnvironment());
+        response.setVersion(buildProperties.getVersion());
+        response.setBuildTime(buildProperties.getTime());
         response.setTimestamp(new Date());
         return new ObjectResponse<>(response);
     }

--- a/powerauth-webflow-client/pom.xml
+++ b/powerauth-webflow-client/pom.xml
@@ -111,6 +111,14 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>build-info</id>
+                        <goals>
+                            <goal>build-info</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/powerauth-webflow-client/src/main/java/io/getlime/security/powerauth/app/webflow/demo/controller/ServiceController.java
+++ b/powerauth-webflow-client/src/main/java/io/getlime/security/powerauth/app/webflow/demo/controller/ServiceController.java
@@ -20,6 +20,7 @@ import io.getlime.core.rest.model.base.response.ObjectResponse;
 import io.getlime.security.powerauth.app.webflow.demo.configuration.WebFlowServiceConfiguration;
 import io.getlime.security.powerauth.app.webflow.demo.model.ServiceStatusResponse;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.info.BuildProperties;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -37,10 +38,12 @@ import java.util.Date;
 public class ServiceController {
 
     private final WebFlowServiceConfiguration webFlowServiceConfiguration;
+    private final BuildProperties buildProperties;
 
     @Autowired
-    public ServiceController(WebFlowServiceConfiguration webFlowServiceConfiguration) {
+    public ServiceController(WebFlowServiceConfiguration webFlowServiceConfiguration, BuildProperties buildProperties) {
         this.webFlowServiceConfiguration = webFlowServiceConfiguration;
+        this.buildProperties = buildProperties;
     }
 
     /**
@@ -53,6 +56,8 @@ public class ServiceController {
         response.setApplicationName(webFlowServiceConfiguration.getApplicationName());
         response.setApplicationDisplayName(webFlowServiceConfiguration.getApplicationDisplayName());
         response.setApplicationEnvironment(webFlowServiceConfiguration.getApplicationEnvironment());
+        response.setVersion(buildProperties.getVersion());
+        response.setBuildTime(buildProperties.getTime());
         response.setTimestamp(new Date());
         return new ObjectResponse<>(response);
     }

--- a/powerauth-webflow-client/src/main/java/io/getlime/security/powerauth/app/webflow/demo/model/ServiceStatusResponse.java
+++ b/powerauth-webflow-client/src/main/java/io/getlime/security/powerauth/app/webflow/demo/model/ServiceStatusResponse.java
@@ -28,6 +28,8 @@ public class ServiceStatusResponse {
     private String applicationName;
     private String applicationDisplayName;
     private String applicationEnvironment;
+    private String version;
+    private Date buildTime;
     private Date timestamp;
 
     /**
@@ -76,6 +78,38 @@ public class ServiceStatusResponse {
      */
     public void setApplicationEnvironment(String applicationEnvironment) {
         this.applicationEnvironment = applicationEnvironment;
+    }
+
+    /**
+     * Get version.
+     * @return version.
+     */
+    public String getVersion() {
+        return version;
+    }
+
+    /**
+     * Set version.
+     * @param version Version.
+     */
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    /**
+     * Get build time.
+     * @return Build time.
+     */
+    public Date getBuildTime() {
+        return buildTime;
+    }
+
+    /**
+     * Set build time.
+     * @param buildTime Build time.
+     */
+    public void setBuildTime(Date buildTime) {
+        this.buildTime = buildTime;
     }
 
     /**

--- a/powerauth-webflow/pom.xml
+++ b/powerauth-webflow/pom.xml
@@ -137,6 +137,23 @@
 
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>build-info</id>
+                        <goals>
+                            <goal>build-info</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <profiles>
         <profile>
             <id>prod</id>
@@ -145,10 +162,6 @@
             </activation>
             <build>
                 <plugins>
-                    <plugin>
-                        <groupId>org.springframework.boot</groupId>
-                        <artifactId>spring-boot-maven-plugin</artifactId>
-                    </plugin>
                     <plugin>
                         <groupId>com.github.eirslett</groupId>
                         <artifactId>frontend-maven-plugin</artifactId>
@@ -198,10 +211,6 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.springframework.boot</groupId>
-                        <artifactId>spring-boot-maven-plugin</artifactId>
-                    </plugin>
-                    <plugin>
                         <groupId>com.github.eirslett</groupId>
                         <artifactId>frontend-maven-plugin</artifactId>
                         <version>1.2</version>
@@ -224,10 +233,6 @@
             <id>dev</id>
             <build>
                 <plugins>
-                    <plugin>
-                        <groupId>org.springframework.boot</groupId>
-                        <artifactId>spring-boot-maven-plugin</artifactId>
-                    </plugin>
                     <plugin>
                         <groupId>com.github.eirslett</groupId>
                         <artifactId>frontend-maven-plugin</artifactId>

--- a/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/controller/ServiceController.java
+++ b/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/controller/ServiceController.java
@@ -20,6 +20,7 @@ import io.getlime.core.rest.model.base.response.ObjectResponse;
 import io.getlime.security.powerauth.app.webflow.configuration.WebFlowServerConfiguration;
 import io.getlime.security.powerauth.app.webflow.model.ServiceStatusResponse;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.info.BuildProperties;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -37,14 +38,17 @@ import java.util.Date;
 public class ServiceController {
 
     private final WebFlowServerConfiguration webFlowServerConfiguration;
+    private final BuildProperties buildProperties;
 
     /**
      * Service constructor.
      * @param webFlowServerConfiguration Web Flow server configuration.
+     * @param buildProperties Build info.
      */
     @Autowired
-    public ServiceController(WebFlowServerConfiguration webFlowServerConfiguration) {
+    public ServiceController(WebFlowServerConfiguration webFlowServerConfiguration, BuildProperties buildProperties) {
         this.webFlowServerConfiguration = webFlowServerConfiguration;
+        this.buildProperties = buildProperties;
     }
 
     /**
@@ -57,6 +61,8 @@ public class ServiceController {
         response.setApplicationName(webFlowServerConfiguration.getApplicationName());
         response.setApplicationDisplayName(webFlowServerConfiguration.getApplicationDisplayName());
         response.setApplicationEnvironment(webFlowServerConfiguration.getApplicationEnvironment());
+        response.setVersion(buildProperties.getVersion());
+        response.setBuildTime(buildProperties.getTime());
         response.setTimestamp(new Date());
         return new ObjectResponse<>(response);
     }

--- a/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/model/ServiceStatusResponse.java
+++ b/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/model/ServiceStatusResponse.java
@@ -28,6 +28,8 @@ public class ServiceStatusResponse {
     private String applicationName;
     private String applicationDisplayName;
     private String applicationEnvironment;
+    private String version;
+    private Date buildTime;
     private Date timestamp;
 
     /**
@@ -76,6 +78,38 @@ public class ServiceStatusResponse {
      */
     public void setApplicationEnvironment(String applicationEnvironment) {
         this.applicationEnvironment = applicationEnvironment;
+    }
+
+    /**
+     * Get version.
+     * @return version.
+     */
+    public String getVersion() {
+        return version;
+    }
+
+    /**
+     * Set version.
+     * @param version Version.
+     */
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    /**
+     * Get build time.
+     * @return Build time.
+     */
+    public Date getBuildTime() {
+        return buildTime;
+    }
+
+    /**
+     * Set build time.
+     * @param buildTime Build time.
+     */
+    public void setBuildTime(Date buildTime) {
+        this.buildTime = buildTime;
     }
 
     /**


### PR DESCRIPTION
This is a quick addition of the version and compilation time. I would like to postpone the refactoring of placing service status API code into a library after the release. Right now there are few lines of duplicate code, but I don't think this is a problem now.