### PR TITLE
Fix #260: Test and fix issues with IE9 and IE10

### DIFF
--- a/powerauth-webflow-client/src/main/resources/templates/layout.html
+++ b/powerauth-webflow-client/src/main/resources/templates/layout.html
@@ -3,8 +3,8 @@
         xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
 >
 <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=11, IE=10, IE=9, IE=edge"/>
     <meta charset="utf-8"/>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
 
     <meta name="description" content=""/>

--- a/powerauth-webflow-i18n/src/main/resources/static/resources/messages_cs.properties
+++ b/powerauth-webflow-i18n/src/main/resources/static/resources/messages_cs.properties
@@ -94,3 +94,6 @@ operation.account=Na účet
 operation.currency=Měna
 operation.note=Poznámka
 operation.dueDate=Splatnost
+
+# Browser support
+browser.unsupported=Váš prohlížeč není podporován. Prosím použijte modernější prohlížeč.

--- a/powerauth-webflow-i18n/src/main/resources/static/resources/messages_en.properties
+++ b/powerauth-webflow-i18n/src/main/resources/static/resources/messages_en.properties
@@ -94,3 +94,6 @@ operation.account=To Account
 operation.currency=Currency
 operation.note=Note
 operation.dueDate=Due Date
+
+# Browser support
+browser.unsupported=Your web browser is not supported. Please switch to a modern web browser.

--- a/powerauth-webflow/package.json
+++ b/powerauth-webflow/package.json
@@ -35,7 +35,8 @@
     "react-intl": "^2.3.0",
     "react-intl-redux": "^0.5.0",
     "hard-source-webpack-plugin": "^0.5.0-rc.2",
-    "bluebird": "^3.5.0"
+    "bluebird": "^3.5.0",
+    "intl": "^1.2.5"
   },
   "scripts": {
     "watch": "webpack --watch -d"

--- a/powerauth-webflow/src/main/js/client.js
+++ b/powerauth-webflow/src/main/js/client.js
@@ -17,6 +17,9 @@
 const React = require('react');
 const ReactDOM = require('react-dom');
 const axiosDefaults = require('axios/lib/defaults');
+
+// Support for browsers which do not have built-in Intl support such as IE 9 and IE 10
+import 'intl';
 // imports
 import {Provider} from "react-redux";
 import {IntlProvider} from "react-intl-redux";
@@ -43,6 +46,17 @@ store.dispatch({
 });
 
 axiosDefaults.headers.common[csrf.headerName] = csrf.token;
+
+// Support: IE 9-11 only, documentMode is an IE-only property
+// https://www.w3schools.com/jsref/prop_doc_documentmode.asp
+var msie = document.documentMode;
+if (msie && msie < 9) {
+    if (lang === "cs") {
+        window.alert(I18N_CS.messages["browser.unsupported"]);
+    } else {
+        window.alert(I18N_EN.messages["browser.unsupported"]);
+    }
+}
 
 const app = document.getElementById('react');
 

--- a/powerauth-webflow/src/main/js/websocket-client.js
+++ b/powerauth-webflow/src/main/js/websocket-client.js
@@ -25,6 +25,12 @@ require('stompjs');
  * @param webSocketId Web Socket ID
  */
 function register(registrations, webSocketId) {
+    var msie = document.documentMode;
+    if (msie && msie < 11) {
+        // Old IE versions do not support Web Sockets, see: https://caniuse.com/#feat=websockets
+        // For IE < 11 fall back to polling.
+        return;
+    }
     let headers = {};
     headers[csrf.headerName] = csrf.token;
     const socket = SockJS('./websocket');
@@ -46,14 +52,18 @@ function register(registrations, webSocketId) {
  * @param message text of the message as JSON
  */
 function send(destination, params, message) {
-    stompClient.send(destination, params, message);
+    if (stompClient !== undefined) {
+        stompClient.send(destination, params, message);
+    }
 }
 
 /**
  * Disconnects the WebSocket.
  */
 function disconnect() {
-    stompClient.disconnect();
+    if (stompClient !== undefined) {
+        stompClient.disconnect();
+    }
 }
 
 module.exports.register = register;

--- a/powerauth-webflow/src/main/resources/templates/index.html
+++ b/powerauth-webflow/src/main/resources/templates/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.w3.org/1999/xhtml">
 <head lang="en">
+    <meta http-equiv="X-UA-Compatible" content="IE=11, IE=10, IE=9, IE=edge"/>
     <meta charset="UTF-8"/>
     <title th:inline="text">[[${title}]]</title>
     <link rel="stylesheet" href="./resources/css/bootstrap.min.css"/>


### PR DESCRIPTION
This PR resolves following items:
* Missing Intl support in IE9, IE10 and other retarded browsers - intl added as a library
* Fixed broken SockJS fallback in IE9 which was opening new windows when connecting - Web Sockets are now disabled in IE < 11
* Updated compatibility meta tag X-UA-Compatible for IE hints
* Warning message for users of IE 8 or older IE browsers which can be updated in I18N messages