### PR TITLE
Fix #276: Invalid message for operation canceled on mobile device

### DIFF
--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/controller/AuthMethodController.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/controller/AuthMethodController.java
@@ -454,7 +454,11 @@ public abstract class AuthMethodController<T extends AuthStepRequest, R extends 
             throw new AuthStepException("operation.notAvailable", new NullPointerException());
         }
         if (operation.getResult() == AuthResult.FAILED) {
-            throw new AuthStepException("operation.alreadyFailed", new IllegalStateException());
+            List<OperationHistory> operationHistory = operation.getHistory();
+            if (operationHistory.size() == 0 || operationHistory.get(operationHistory.size()-1).getRequestAuthStepResult() != AuthStepResult.CANCELED) {
+                // allow displaying of canceled operations - operation may be canceled in mobile app and later displayed in web UI
+                throw new AuthStepException("operation.alreadyFailed", new IllegalStateException());
+            }
         }
         if (operation.isExpired()) {
             throw new AuthStepException("operation.timeout", new IllegalStateException());


### PR DESCRIPTION
We need to allow operations to be valid in status FAILED/CANCELED in order to display a message about canceled operation when operation gets canceled in Mobile Token app.