### PR TITLE
Fix #328: Fix pom.xml files to release only the public artifacts

### DIFF
--- a/powerauth-data-adapter/pom.xml
+++ b/powerauth-data-adapter/pom.xml
@@ -94,6 +94,13 @@
                 <artifactId>maven-war-plugin</artifactId>
                 <version>${maven-war-plugin.version}</version>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/powerauth-webflow-authentication-form/pom.xml
+++ b/powerauth-webflow-authentication-form/pom.xml
@@ -25,4 +25,16 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/powerauth-webflow-authentication-init/pom.xml
+++ b/powerauth-webflow-authentication-init/pom.xml
@@ -25,4 +25,16 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/powerauth-webflow-authentication-mtoken/pom.xml
+++ b/powerauth-webflow-authentication-mtoken/pom.xml
@@ -101,4 +101,16 @@
         </profile>
     </profiles>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/powerauth-webflow-authentication-operation-review/pom.xml
+++ b/powerauth-webflow-authentication-operation-review/pom.xml
@@ -41,4 +41,16 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/powerauth-webflow-authentication-sms/pom.xml
+++ b/powerauth-webflow-authentication-sms/pom.xml
@@ -46,4 +46,16 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/powerauth-webflow-authentication/pom.xml
+++ b/powerauth-webflow-authentication/pom.xml
@@ -92,4 +92,16 @@
         </profile>
     </profiles>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/powerauth-webflow-i18n/pom.xml
+++ b/powerauth-webflow-i18n/pom.xml
@@ -49,4 +49,16 @@
         </profile>
     </profiles>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/powerauth-webflow-resources/pom.xml
+++ b/powerauth-webflow-resources/pom.xml
@@ -55,4 +55,16 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/powerauth-webflow/pom.xml
+++ b/powerauth-webflow/pom.xml
@@ -161,6 +161,13 @@
                 <artifactId>maven-war-plugin</artifactId>
                 <version>${maven-war-plugin.version}</version>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
We need to fix this in order to automatically release the correct libraries, not our internals.