### PR TITLE
Fix #354: REST API returns 500 when operation is already processed

### DIFF
--- a/powerauth-mtoken-model/src/main/java/io/getlime/security/powerauth/lib/mtoken/model/enumeration/ErrorCode.java
+++ b/powerauth-mtoken-model/src/main/java/io/getlime/security/powerauth/lib/mtoken/model/enumeration/ErrorCode.java
@@ -59,6 +59,12 @@ public class ErrorCode {
     public static final String OPERATION_ALREADY_FAILED     = "OPERATION_ALREADY_FAILED";
 
     /**
+     * Error code for situation when an operation was canceled and yet, some further
+     * action other than cancellation was requested with that operation.
+     */
+    public static final String OPERATION_ALREADY_CANCELED   = "OPERATION_ALREADY_CANCELED";
+
+    /**
      * Error code for situation when an operation expired and yet, some further
      * action was requested with that operation.
      */

--- a/powerauth-nextstep-client/src/main/java/io/getlime/security/powerauth/lib/nextstep/client/NextStepClient.java
+++ b/powerauth-nextstep-client/src/main/java/io/getlime/security/powerauth/lib/nextstep/client/NextStepClient.java
@@ -26,6 +26,7 @@ import io.getlime.security.powerauth.lib.nextstep.model.entity.OperationFormData
 import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthMethod;
 import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthStepResult;
 import io.getlime.security.powerauth.lib.nextstep.model.exception.NextStepServiceException;
+import io.getlime.security.powerauth.lib.nextstep.model.exception.OperationAlreadyCanceledException;
 import io.getlime.security.powerauth.lib.nextstep.model.exception.OperationAlreadyFailedException;
 import io.getlime.security.powerauth.lib.nextstep.model.exception.OperationAlreadyFinishedException;
 import io.getlime.security.powerauth.lib.nextstep.model.request.*;
@@ -423,6 +424,8 @@ public class NextStepClient {
                     throw new OperationAlreadyFinishedException(error.getMessage());
                 case OperationAlreadyFailedException.CODE:
                     throw new OperationAlreadyFailedException(error.getMessage());
+                case OperationAlreadyCanceledException.CODE:
+                    throw new OperationAlreadyCanceledException(error.getMessage());
                 default:
                     return new NextStepServiceException(ex, error);
             }

--- a/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/exception/OperationAlreadyCanceledException.java
+++ b/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/exception/OperationAlreadyCanceledException.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.lib.nextstep.model.exception;
+
+import io.getlime.core.rest.model.base.entity.Error;
+
+/**
+ * Exception for case when operation was previously canceled and it is being updated.
+ *
+ * @author Roman Strobl, roman.strobl@lime-company.eu
+ */
+public class OperationAlreadyCanceledException extends NextStepServiceException {
+
+    public static final String CODE = "OPERATION_ALREADY_CANCELED";
+
+    private Error error;
+
+    /**
+     * Constructor with error message.
+     * @param message Error message.
+     */
+    public OperationAlreadyCanceledException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructor with cause.
+     * @param cause Original exception.
+     */
+    public OperationAlreadyCanceledException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructor with cause and error details.
+     * @param cause Original exception.
+     * @param error Object with error information.
+     */
+    public OperationAlreadyCanceledException(Throwable cause, Error error) {
+        super(cause);
+        this.error = error;
+    }
+
+    /**
+     * Get error detail information.
+     * @return Error detail information.
+     */
+    public Error getError() {
+        return error;
+    }
+}

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/exception/DefaultExceptionResolver.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/exception/DefaultExceptionResolver.java
@@ -19,6 +19,7 @@ package io.getlime.security.powerauth.app.nextstep.exception;
 import io.getlime.core.rest.model.base.entity.Error;
 import io.getlime.core.rest.model.base.response.ErrorResponse;
 import io.getlime.core.rest.model.base.response.ObjectResponse;
+import io.getlime.security.powerauth.lib.nextstep.model.exception.OperationAlreadyCanceledException;
 import io.getlime.security.powerauth.lib.nextstep.model.exception.OperationAlreadyFailedException;
 import io.getlime.security.powerauth.lib.nextstep.model.exception.OperationAlreadyFinishedException;
 import org.springframework.http.HttpStatus;
@@ -74,6 +75,19 @@ public class DefaultExceptionResolver {
     public @ResponseBody ObjectResponse<Error> handleOperationAlreadyFailedException(OperationAlreadyFailedException ex) {
         Logger.getLogger(this.getClass().getName()).log(Level.WARNING, "Error occurred in Next Step server: {0}", ex.getMessage());
         Error error = new Error(OperationAlreadyFailedException.CODE, "Operation is already in FAILED state.");
+        return new ErrorResponse(error);
+    }
+
+    /**
+     * Exception handler for operation already canceled error.
+     * @param ex Exception.
+     * @return Response with error details.
+     */
+    @ExceptionHandler(OperationAlreadyCanceledException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public @ResponseBody ObjectResponse<Error> handleOperationCanceledException(OperationAlreadyCanceledException ex) {
+        Logger.getLogger(this.getClass().getName()).log(Level.WARNING, "Error occurred in Next Step server: {0}", ex.getMessage());
+        Error error = new Error(OperationAlreadyCanceledException.CODE, "Operation update attempted for CANCELED operation.");
         return new ErrorResponse(error);
     }
 }

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/StepResolutionService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/StepResolutionService.java
@@ -29,6 +29,7 @@ import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthResult;
 import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthStepResult;
 import io.getlime.security.powerauth.lib.nextstep.model.enumeration.OperationRequestType;
 import io.getlime.security.powerauth.lib.nextstep.model.exception.NextStepServiceException;
+import io.getlime.security.powerauth.lib.nextstep.model.exception.OperationAlreadyCanceledException;
 import io.getlime.security.powerauth.lib.nextstep.model.exception.OperationAlreadyFailedException;
 import io.getlime.security.powerauth.lib.nextstep.model.exception.OperationAlreadyFinishedException;
 import io.getlime.security.powerauth.lib.nextstep.model.request.CreateOperationRequest;
@@ -407,12 +408,10 @@ public class StepResolutionService {
         if (initOperationItem.getRequestAuthMethod() != AuthMethod.INIT || initOperationItem.getRequestAuthStepResult() != AuthStepResult.CONFIRMED) {
             throw new IllegalStateException("Operation update failed, because INIT step for this operation is invalid (operationId: " + request.getOperationId() + ").");
         }
-        // check whether request AuthMethod is available in response AuthSteps - this verifies operation continuity
-        // the only exception is INIT method which can cancel other operations due to concurrency check
-        boolean stepAuthMethodValid = false;
-        if (request.getAuthStepResult() == AuthStepResult.CANCELED && request.getAuthMethod() == AuthMethod.INIT) {
-            stepAuthMethodValid = true;
-        } else {
+        OperationHistoryEntity currentOperationHistory = operationEntity.getCurrentOperationHistoryEntity();
+        if (currentOperationHistory.getResponseResult() == AuthResult.CONTINUE) {
+            boolean stepAuthMethodValid = false;
+            // check whether request AuthMethod is available in response AuthSteps - this verifies operation continuity
             if (request.getAuthMethod() == AuthMethod.SHOW_OPERATION_DETAIL) {
                 // special handling for SHOW_OPERATION_DETAIL - either SMS_KEY or POWERAUTH_TOKEN are present in next steps
                 for (AuthStep step : operationPersistenceService.getResponseAuthSteps(operationEntity)) {
@@ -430,18 +429,21 @@ public class StepResolutionService {
                     }
                 }
             }
-        }
-        if (!stepAuthMethodValid) {
-            throw new IllegalStateException("Operation update failed, because AuthMethod is invalid (operationId: " + request.getOperationId() + ").");
+            if (!stepAuthMethodValid) {
+                throw new IllegalStateException("Operation update failed, because authentication method is invalid (operationId: " + request.getOperationId() + ").");
+            }
         }
         for (OperationHistoryEntity historyItem : operationHistory) {
             if (historyItem.getResponseResult() == AuthResult.DONE) {
                 throw new OperationAlreadyFinishedException("Operation update failed, because operation is already in DONE state (operationId: " + request.getOperationId() + ").");
             }
             if (historyItem.getResponseResult() == AuthResult.FAILED) {
-                // #102 - allow double cancellation requests, cancel requests may come from multiple channels, so this is a supported scenario
-                if (operationEntity.getCurrentOperationHistoryEntity().getRequestAuthStepResult() != AuthStepResult.CANCELED
-                        || request.getAuthStepResult() != AuthStepResult.CANCELED) {
+                // Do not allow to update a canceled operation (e.g. authorize an operation which is canceled),
+                // unless the request is a cancellation request - double cancellation of operations is allowed.
+                if (historyItem.getRequestAuthStepResult() == AuthStepResult.CANCELED && request.getAuthStepResult() != AuthStepResult.CANCELED) {
+                    throw new OperationAlreadyCanceledException("Operation update failed, because operation is canceled (operationId: " + request.getOperationId() + ").");
+                } else if (request.getAuthStepResult() != AuthStepResult.CANCELED) {
+                    // #102 - allow double cancellation requests, cancel requests may come from multiple channels, so this is a supported scenario
                     throw new OperationAlreadyFailedException("Operation update failed, because operation is already in FAILED state (operationId: " + request.getOperationId() + ").");
                 }
             }

--- a/powerauth-webflow-authentication-form/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/form/controller/FormLoginController.java
+++ b/powerauth-webflow-authentication-form/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/form/controller/FormLoginController.java
@@ -186,7 +186,7 @@ public class FormLoginController extends AuthMethodController<UsernamePasswordAu
     public @ResponseBody UsernamePasswordAuthenticationResponse cancelAuthentication() throws AuthStepException {
         try {
             final GetOperationDetailResponse operation = getOperation();
-            cancelAuthorization(operation.getOperationId(), null, OperationCancelReason.UNKNOWN, null);
+            cancelAuthorization(operation.getOperationId(), operation.getUserId(), OperationCancelReason.UNKNOWN, null);
             final UsernamePasswordAuthenticationResponse response = new UsernamePasswordAuthenticationResponse();
             response.setResult(AuthStepResult.CANCELED);
             response.setMessage("operation.canceled");

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileAppApiController.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileAppApiController.java
@@ -19,6 +19,9 @@ import io.getlime.core.rest.model.base.request.ObjectRequest;
 import io.getlime.core.rest.model.base.response.ObjectResponse;
 import io.getlime.core.rest.model.base.response.Response;
 import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
+import io.getlime.security.powerauth.lib.mtoken.model.entity.AllowedSignatureType;
+import io.getlime.security.powerauth.lib.mtoken.model.request.OperationApproveRequest;
+import io.getlime.security.powerauth.lib.mtoken.model.request.OperationRejectRequest;
 import io.getlime.security.powerauth.lib.mtoken.model.response.OperationListResponse;
 import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthMethod;
 import io.getlime.security.powerauth.lib.nextstep.model.enumeration.OperationCancelReason;
@@ -32,10 +35,7 @@ import io.getlime.security.powerauth.lib.webflow.authentication.mtoken.errorhand
 import io.getlime.security.powerauth.lib.webflow.authentication.mtoken.errorhandling.exception.MobileAppApiException;
 import io.getlime.security.powerauth.lib.webflow.authentication.mtoken.errorhandling.exception.OperationExpiredException;
 import io.getlime.security.powerauth.lib.webflow.authentication.mtoken.model.converter.OperationConverter;
-import io.getlime.security.powerauth.lib.mtoken.model.entity.AllowedSignatureType;
 import io.getlime.security.powerauth.lib.webflow.authentication.mtoken.model.request.MobileTokenAuthenticationRequest;
-import io.getlime.security.powerauth.lib.mtoken.model.request.OperationRejectRequest;
-import io.getlime.security.powerauth.lib.mtoken.model.request.OperationApproveRequest;
 import io.getlime.security.powerauth.lib.webflow.authentication.mtoken.model.response.MobileTokenAuthenticationResponse;
 import io.getlime.security.powerauth.lib.webflow.authentication.mtoken.service.WebSocketMessageService;
 import io.getlime.security.powerauth.lib.webflow.authentication.service.AuthMethodQueryService;
@@ -193,7 +193,9 @@ public class MobileAppApiController extends AuthMethodController<MobileTokenAuth
             if (operation.isExpired()) {
                 throw new OperationExpiredException();
             }
-            if (operation.getOperationData().equals(request.getRequestObject().getData()) && operation.getUserId().equals(apiAuthentication.getUserId())) {
+            if (operation.getOperationData().equals(request.getRequestObject().getData())
+                    && operation.getUserId() != null
+                    && operation.getUserId().equals(apiAuthentication.getUserId())) {
                 final UpdateOperationResponse updateOperationResponse = authorize(operationId, userId);
                 webSocketMessageService.notifyAuthorizationComplete(operationId, updateOperationResponse.getResult());
                 return new Response();

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileTokenOfflineController.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileTokenOfflineController.java
@@ -280,7 +280,7 @@ public class MobileTokenOfflineController extends AuthMethodController<QRCodeAut
         }
         try {
             GetOperationDetailResponse operation = getOperation();
-            cancelAuthorization(operation.getOperationId(), null, OperationCancelReason.UNKNOWN, null);
+            cancelAuthorization(operation.getOperationId(), operation.getUserId(), OperationCancelReason.UNKNOWN, null);
             final QRCodeAuthenticationResponse response = new QRCodeAuthenticationResponse();
             response.setResult(AuthStepResult.CANCELED);
             response.setMessage("operation.canceled");

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileTokenOnlineController.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileTokenOnlineController.java
@@ -306,7 +306,7 @@ public class MobileTokenOnlineController extends AuthMethodController<MobileToke
     public @ResponseBody MobileTokenAuthenticationResponse cancelAuthentication() throws AuthStepException {
         try {
             GetOperationDetailResponse operation = getOperation();
-            cancelAuthorization(operation.getOperationId(), null, OperationCancelReason.UNKNOWN, null);
+            cancelAuthorization(operation.getOperationId(), operation.getUserId(), OperationCancelReason.UNKNOWN, null);
             final MobileTokenAuthenticationResponse response = new MobileTokenAuthenticationResponse();
             response.setResult(AuthStepResult.CANCELED);
             response.setMessage("operation.canceled");

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/errorhandling/MobileApiExceptionResolver.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/errorhandling/MobileApiExceptionResolver.java
@@ -18,6 +18,7 @@ package io.getlime.security.powerauth.lib.webflow.authentication.mtoken.errorhan
 import io.getlime.core.rest.model.base.entity.Error;
 import io.getlime.core.rest.model.base.response.ErrorResponse;
 import io.getlime.security.powerauth.lib.mtoken.model.enumeration.ErrorCode;
+import io.getlime.security.powerauth.lib.nextstep.model.exception.OperationAlreadyCanceledException;
 import io.getlime.security.powerauth.lib.nextstep.model.exception.OperationAlreadyFailedException;
 import io.getlime.security.powerauth.lib.nextstep.model.exception.OperationAlreadyFinishedException;
 import io.getlime.security.powerauth.lib.webflow.authentication.mtoken.errorhandling.exception.InvalidActivationException;
@@ -116,6 +117,17 @@ public class MobileApiExceptionResolver {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public @ResponseBody ErrorResponse handleOperationAlreadyFailedException(Throwable t) {
         return error(ErrorCode.OPERATION_ALREADY_FAILED, t);
+    }
+
+    /**
+     * Exception handler for canceled operations.
+     * @param t Throwable.
+     * @return Response with error details.
+     */
+    @ExceptionHandler(OperationAlreadyCanceledException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public @ResponseBody ErrorResponse handleOperationCanceledException(Throwable t) {
+        return error(ErrorCode.OPERATION_ALREADY_CANCELED, t);
     }
 
     /**

--- a/powerauth-webflow-authentication-operation-review/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/operation/controller/OperationReviewController.java
+++ b/powerauth-webflow-authentication-operation-review/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/operation/controller/OperationReviewController.java
@@ -187,7 +187,7 @@ public class OperationReviewController extends AuthMethodController<OperationRev
     public @ResponseBody OperationReviewResponse cancelAuthentication() throws AuthStepException {
         try {
             GetOperationDetailResponse operation = getOperation();
-            cancelAuthorization(operation.getOperationId(), null, OperationCancelReason.UNKNOWN, null);
+            cancelAuthorization(operation.getOperationId(), operation.getUserId(), OperationCancelReason.UNKNOWN, null);
             final OperationReviewResponse response = new OperationReviewResponse();
             response.setResult(AuthStepResult.CANCELED);
             response.setMessage("operation.canceled");

--- a/powerauth-webflow-authentication-sms/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/sms/controller/SMSAuthorizationController.java
+++ b/powerauth-webflow-authentication-sms/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/sms/controller/SMSAuthorizationController.java
@@ -214,7 +214,7 @@ public class SMSAuthorizationController extends AuthMethodController<SMSAuthoriz
         try {
             final GetOperationDetailResponse operation = getOperation();
             httpSession.removeAttribute(MESSAGE_ID);
-            cancelAuthorization(operation.getOperationId(), null, OperationCancelReason.UNKNOWN, null);
+            cancelAuthorization(operation.getOperationId(), operation.getUserId(), OperationCancelReason.UNKNOWN, null);
             final SMSAuthorizationResponse cancelResponse = new SMSAuthorizationResponse();
             cancelResponse.setResult(AuthStepResult.CANCELED);
             cancelResponse.setMessage("operation.canceled");


### PR DESCRIPTION
Fix includes:
* Fixed incorrect validation logic for next steps (validation should be only done for result = AuthResult.CONTINUE)
* Added specific Exception for case when canceled operation is being updated - OperationAlreadyCanceledException, this Exception is exported in Mobile Token API
* Added missing user IDs into cancelAuthorization calls (when user canceled the operation, the userId was changed to null in database, so information about previously authenticated user was lost)