### PR TITLE
Fix #362: Web Flow does not start on Wildfly AS

### DIFF
--- a/powerauth-webflow/pom.xml
+++ b/powerauth-webflow/pom.xml
@@ -63,6 +63,13 @@
             <artifactId>spring-security-messaging</artifactId>
         </dependency>
 
+        <!-- Set scope of tomcat-embed-websocket to provided to avoid startup errors on WildFly -->
+        <dependency>
+            <artifactId>tomcat-embed-websocket</artifactId>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Other Dependencies -->
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
I excluded the `tomcat-embed-websocket` artifact in main pom.xml, there is no class conflict anymore and Web Flow runs on Wildfly AS.