### PR TITLE
Fix #369: Fix default client credentials to use bcrypt

### DIFF
--- a/docs/sql/mysql/initial_data.sql
+++ b/docs/sql/mysql/initial_data.sql
@@ -1,5 +1,7 @@
+-- default oauth 2.0 client
+-- Note: bcrypt('changeme', 12) => '$2a$12$MkYsT5igDXSDgRwyDVz1B.93h8F81E4GZJd/spy/1vhjM4CJgeed.'
 INSERT INTO oauth_client_details (client_id, client_secret, scope, authorized_grant_types, additional_information, autoapprove)
-VALUES ('democlient', 'changeme', 'profile', 'authorization_code', '{}', 'true');
+VALUES ('democlient', '$2a$12$MkYsT5igDXSDgRwyDVz1B.93h8F81E4GZJd/spy/1vhjM4CJgeed.', 'profile', 'authorization_code', '{}', 'true');
 
 -- authentication methods
 INSERT INTO ns_auth_method (auth_method, order_number, check_user_prefs, user_prefs_column, user_prefs_default, check_auth_fails, max_auth_fails, has_user_interface, display_name_key)

--- a/docs/sql/oracle/initial_data.sql
+++ b/docs/sql/oracle/initial_data.sql
@@ -1,5 +1,7 @@
+-- default oauth 2.0 client
+-- Note: bcrypt('changeme', 12) => '$2a$12$MkYsT5igDXSDgRwyDVz1B.93h8F81E4GZJd/spy/1vhjM4CJgeed.'
 INSERT INTO oauth_client_details (client_id, client_secret, scope, authorized_grant_types, additional_information, autoapprove)
-VALUES ('democlient', 'changeme', 'profile', 'authorization_code', '{}', 'true');
+VALUES ('democlient', '$2a$12$MkYsT5igDXSDgRwyDVz1B.93h8F81E4GZJd/spy/1vhjM4CJgeed.', 'profile', 'authorization_code', '{}', 'true');
 
 -- authentication methods
 INSERT INTO ns_auth_method (auth_method, order_number, check_user_prefs, user_prefs_column, user_prefs_default, check_auth_fails, max_auth_fails, has_user_interface, display_name_key)


### PR DESCRIPTION
Here is the migration guide for this change:

https://github.com/lime-company/powerauth-webflow/wiki/Web-Flow-0.20.0#db-migration-to-bcrypt