### PR TITLE
Fix #383: Unable to cancel operation on mobile token in case of timeout

### DIFF
--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/errorhandling/MobileApiExceptionResolver.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/errorhandling/MobileApiExceptionResolver.java
@@ -21,6 +21,7 @@ import io.getlime.security.powerauth.lib.mtoken.model.enumeration.ErrorCode;
 import io.getlime.security.powerauth.lib.nextstep.model.exception.OperationAlreadyCanceledException;
 import io.getlime.security.powerauth.lib.nextstep.model.exception.OperationAlreadyFailedException;
 import io.getlime.security.powerauth.lib.nextstep.model.exception.OperationAlreadyFinishedException;
+import io.getlime.security.powerauth.lib.webflow.authentication.exception.OperationTimeoutException;
 import io.getlime.security.powerauth.lib.webflow.authentication.mtoken.errorhandling.exception.InvalidActivationException;
 import io.getlime.security.powerauth.lib.webflow.authentication.mtoken.errorhandling.exception.InvalidRequestObjectException;
 import io.getlime.security.powerauth.lib.webflow.authentication.mtoken.errorhandling.exception.OperationExpiredException;
@@ -140,4 +141,16 @@ public class MobileApiExceptionResolver {
     public @ResponseBody ErrorResponse handleOperationExpiredException(Throwable t) {
         return error(ErrorCode.OPERATION_EXPIRED, t);
     }
+
+    /**
+     * Exception handler for operation timeout exception.
+     * @param t Throwable.
+     * @return Response with error details.
+     */
+    @ExceptionHandler(OperationTimeoutException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public @ResponseBody ErrorResponse handleOperationTimeoutException(Throwable t) {
+        return error(ErrorCode.OPERATION_EXPIRED, t);
+    }
+
 }


### PR DESCRIPTION
Added an extra handler for the specific exception type.
After checking with mobile team, we do not need to introduce a new error code.